### PR TITLE
path.Join replaced by filepath.Join

### DIFF
--- a/revel/build.go
+++ b/revel/build.go
@@ -100,13 +100,13 @@ func buildApp(args []string) {
 
 	mustRenderTemplate(
 		runShPath,
-		path.Join(revel.RevelPath, "../cmd/revel", "package_run.sh.template"),
+		filepath.Join(revel.RevelPath, "../cmd/revel", "package_run.sh.template"),
 		tmplData)
 
 	mustChmod(runShPath, 0755)
 
 	mustRenderTemplate(
-		path.Join(destPath, "run.bat"),
-		path.Join(revel.RevelPath, "../cmd/revel", "package_run.bat.template"),
+		filepath.Join(destPath, "run.bat"),
+		filepath.Join(revel.RevelPath, "../cmd/revel", "package_run.bat.template"),
 		tmplData)
 }


### PR DESCRIPTION
Here is a proposal to fix #4.
path.Join does not manage Windows separators correctly. From the official Go code, path.Join is:
    return Clean(strings.Join(elem[i:], "/"))
while filepath.Join is:
    return Clean(strings.Join(elem[i:], string(Separator)))
Seperator is OS-dependent so that filepath.Join is the one giving the expected behavior on all platforms.
