### PR TITLE
Add environment mode to package.

### DIFF
--- a/revel/build.go
+++ b/revel/build.go
@@ -31,12 +31,12 @@ func init() {
 }
 
 func buildApp(args []string) {
-	if len(args) != 2 {
+	if len(args) != 3 {
 		fmt.Fprintf(os.Stderr, "%s\n%s", cmdBuild.UsageLine, cmdBuild.Long)
 		return
 	}
 
-	appImportPath, destPath := args[0], args[1]
+	appImportPath, destPath, mode := args[0], args[1], args[2]
 	if !revel.Initialized {
 		revel.Init("", appImportPath, "")
 	}
@@ -96,6 +96,7 @@ func buildApp(args []string) {
 	tmplData, runShPath := map[string]interface{}{
 		"BinName":    filepath.Base(app.BinaryPath),
 		"ImportPath": appImportPath,
+		"Mode":       mode,
 	}, path.Join(destPath, "run.sh")
 
 	mustRenderTemplate(

--- a/revel/package.go
+++ b/revel/package.go
@@ -2,18 +2,24 @@ package main
 
 import (
 	"fmt"
-	"github.com/revel/revel"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/revel/revel"
 )
 
 var cmdPackage = &Command{
-	UsageLine: "package [import path]",
+	UsageLine: "package [import path] [run mode]",
 	Short:     "package a Revel application (e.g. for deployment)",
 	Long: `
 Package the Revel web application named by the given import path.
 This allows it to be deployed and run on a machine that lacks a Go installation.
+
+The run mode is used to select which set of app.conf configuration should
+apply and may be used to determine logic in the application itself.
+
+Run mode defaults to "prod".
 
 For example:
 
@@ -31,6 +37,12 @@ func packageApp(args []string) {
 		return
 	}
 
+	// Determine the run mode.
+	mode := "prod"
+	if len(args) >= 2 {
+		mode = args[1]
+	}
+
 	appImportPath := args[0]
 	revel.Init("", appImportPath, "")
 
@@ -42,7 +54,7 @@ func packageApp(args []string) {
 	tmpDir, err := ioutil.TempDir("", filepath.Base(revel.BasePath))
 	panicOnError(err, "Failed to get temp dir")
 
-	buildApp([]string{args[0], tmpDir})
+	buildApp([]string{args[0], tmpDir, mode})
 
 	// Create the zip file.
 	archiveName := mustTarGzDir(destFile, tmpDir)

--- a/revel/package_run.bat.template
+++ b/revel/package_run.bat.template
@@ -1,2 +1,2 @@
 @echo off
-{{.BinName}} -importPath {{.ImportPath}} -srcPath %CD%\src -runMode prod
+{{.BinName}} -importPath {{.ImportPath}} -srcPath %CD%\src -runMode {{.Mode}}

--- a/revel/package_run.sh.template
+++ b/revel/package_run.sh.template
@@ -1,3 +1,3 @@
 #!/bin/sh
 SCRIPTPATH=$(cd "$(dirname "$0")"; pwd)
-"$SCRIPTPATH/{{.BinName}}" -importPath {{.ImportPath}} -srcPath "$SCRIPTPATH/src" -runMode prod
+"$SCRIPTPATH/{{.BinName}}" -importPath {{.ImportPath}} -srcPath "$SCRIPTPATH/src" -runMode {{.Mode}}


### PR DESCRIPTION
Packaging assumes production, but since you can define new ones in app.conf, it would seem to make sense to have an option to package for other environments.