### PR TITLE
Use a separate directory for revel project binaries

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -61,7 +61,9 @@ func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
 	if err != nil {
 		revel.ERROR.Fatalln("Failure importing", revel.ImportPath)
 	}
-	binName := path.Join(pkg.BinDir, "revel.d", path.Base(revel.BasePath))
+
+	// Binary path is a combination of $GOBIN/revel.d directory, app's import path and its name.
+	binName := path.Join(pkg.BinDir, "revel.d", revel.ImportPath, path.Base(revel.BasePath))
 
 	// Change binary path for Windows build
 	goos := runtime.GOOS

--- a/harness/build.go
+++ b/harness/build.go
@@ -61,7 +61,7 @@ func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
 	if err != nil {
 		revel.ERROR.Fatalln("Failure importing", revel.ImportPath)
 	}
-	binName := path.Join(pkg.BinDir, path.Base(revel.BasePath))
+	binName := path.Join(pkg.BinDir, "revel.d", path.Base(revel.BasePath))
 
 	// Change binary path for Windows build
 	goos := runtime.GOOS


### PR DESCRIPTION
#### Description
Revel overrides binaries in `$GOPATH/bin`. For example, we may want to create a project `golint`:
```sh
$ revel new github.com/anonx/golint
```
After, starting it as `revel run github.com/anonx/golint`, a new binary `$GOPATH/bin/golint` will be created instead of our `golint` linter. At the same time, we are not getting any notifications or questions whether we want to override it.

As a solution, we are just creating `revel.d` directory in `$GOPATH/bin` and storing compiled revel projects there.

* The dir name is `revel.d`, but not `revel` because we have already had `revel` binary there and Linux doesn't allow us to have both file and dir with the same names at the same place.
* We are still using `$GOPATH/bin` rather than project's import path as there may be not enough privileges on `$GOPATH/src`. For example, if `$GOPATH/src` is used on a drive which is mounted with `noexec`.

#### Limitations
Conflicts still possible. For example, if are running two projects with the same name:
```sh
$ revel run bitbucket.org/username/helloworld
$ revel run github.com/username/helloworld
```
So, probably, we should do something with `path.Base(revel.BasePath)` as well. Thoughts?