### PR TITLE
Allow SelectorExpr as RenderArgs

### DIFF
--- a/harness/reflect.go
+++ b/harness/reflect.go
@@ -478,11 +478,21 @@ func appendAction(fset *token.FileSet, mm methodMap, decl ast.Decl, pkgImportPat
 			Names: []string{},
 		}
 		for _, arg := range callExpr.Args {
-			argIdent, ok := arg.(*ast.Ident)
-			if !ok {
+			argName := ""
+			switch t := arg.(type) {
+			case *ast.Ident:
+				argName = t.Name
+			case *ast.SelectorExpr:
+				xIdent, ok := t.X.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				argName = xIdent.Name + "_" + t.Sel.Name
+			default:
 				continue
 			}
-			methodCall.Names = append(methodCall.Names, argIdent.Name)
+
+			methodCall.Names = append(methodCall.Names, argName)
 		}
 		method.RenderCalls = append(method.RenderCalls, methodCall)
 		return true


### PR DESCRIPTION
Allows code like

```
func (c MyController) Index() revel.Result {
    return c.Render(myotherpackage.Data)
}
```

```
<p>my data is: {{.myotherpackage_Data}}</p>
```
