### PR TITLE
Ignore missing temporary directories in build.cleanDir

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -173,7 +173,9 @@ func cleanDir(dir string) {
 	tmpPath := path.Join(revel.AppPath, dir)
 	f, err := os.Open(tmpPath)
 	if err != nil {
-		revel.ERROR.Println("Failed to clean dir:", err)
+		if !os.IsNotExist(err) {
+			revel.ERROR.Println("Failed to clean dir:", err)
+		}
 	} else {
 		defer f.Close()
 		infos, err := f.Readdir(0)


### PR DESCRIPTION
Otherwise, removing your `app/tmp` and `app/routes` folders prior to booting (e.g., if you add them to your .gitignore and use Travis) will cause unnecessary FATAL error messages. Fixes revel/revel#908.

Before:
```
INFO  2015/07/06 23:14:54 revel.go:206: Initialized Revel v0.12.0 (2015-03-25) for >= go1.3
INFO  2015/07/06 23:14:54 build.go:172: Cleaning dir tmp
ERROR 2015/07/06 23:14:54 build.go:176: Failed to clean dir: open /home/robert/Sandbox/go/src/github.com/rnubel/revel-test/app/tmp: no such file or directory
INFO  2015/07/06 23:14:54 build.go:172: Cleaning dir routes
ERROR 2015/07/06 23:14:54 build.go:176: Failed to clean dir: open /home/robert/Sandbox/go/src/github.com/rnubel/revel-test/app/routes: no such file or directory
INFO  2015/07/06 23:14:54 build.go:172: Cleaning dir tmp
ERROR 2015/07/06 23:14:54 build.go:176: Failed to clean dir: open /home/robert/Sandbox/go/src/github.com/rnubel/revel-test/app/tmp: no such file or directory
INFO  2015/07/06 23:14:54 build.go:172: Cleaning dir routes
ERROR 2015/07/06 23:14:54 build.go:176: Failed to clean dir: open /home/robert/Sandbox/go/src/github.com/rnubel/revel-test/app/routes: no such file or directory
```

After:
```
INFO  2015/07/06 23:18:56 revel.go:206: Initialized Revel v0.12.0 (2015-03-25) for >= go1.3
INFO  2015/07/06 23:18:56 build.go:172: Cleaning dir tmp
INFO  2015/07/06 23:18:56 build.go:172: Cleaning dir routes
INFO  2015/07/06 23:18:57 build.go:172: Cleaning dir tmp
INFO  2015/07/06 23:18:57 build.go:172: Cleaning dir routes
```