### PR TITLE
Expose code generation via its own command

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -25,27 +25,14 @@ var importErrorPattern = regexp.MustCompile("cannot find package \"([^\"]+)\"")
 // Returns the path to the built binary, and an error if there was a problem building it.
 func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
 	// First, clear the generated files (to avoid them messing with ProcessSource).
-	cleanSource("tmp", "routes")
+	cleanSource("app/tmp", "app/routes")
 
-	sourceInfo, compileError := ProcessSource(revel.CodePaths)
+	templateArgs, compileError := preProcess()
 	if compileError != nil {
 		return nil, compileError
 	}
 
-	// Add the db.import to the import paths.
-	if dbImportPath, found := revel.Config.String("db.import"); found {
-		sourceInfo.InitImportPaths = append(sourceInfo.InitImportPaths, dbImportPath)
-	}
-
-	// Generate two source files.
-	templateArgs := map[string]interface{}{
-		"Controllers":    sourceInfo.ControllerSpecs(),
-		"ValidationKeys": sourceInfo.ValidationKeys,
-		"ImportPaths":    calcImportAliases(sourceInfo),
-		"TestSuites":     sourceInfo.TestSuites(),
-	}
-	genSource("tmp", "main.go", MAIN, templateArgs)
-	genSource("routes", "routes.go", ROUTES, templateArgs)
+	generate("app/tmp", templateArgs)
 
 	// Read build config.
 	buildTags := revel.Config.StringDefault("build.tags", "")
@@ -128,6 +115,53 @@ func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
 	return nil, nil
 }
 
+// Generate the app:
+// 1. Generate the main.go file.
+// 2. Generate the routes.go file.
+// Requires that revel.Init has been called previously.
+// Returns an error if there was a problem processing the source.
+func Generate(mainDir string, initDirectly bool) *revel.Error {
+	// First, clear the generated files (to avoid them messing with ProcessSource).
+	cleanSource(mainDir, "app/routes")
+
+	templateArgs, compileError := preProcess()
+	if compileError != nil {
+		return compileError
+	}
+
+	templateArgs["initDirectly"] = initDirectly
+
+	generate(mainDir, templateArgs)
+	return nil
+}
+
+func preProcess() (templateArgs map[string]interface{}, compileError *revel.Error) {
+	sourceInfo, compileError := ProcessSource(revel.CodePaths)
+	if compileError != nil {
+		return nil, compileError
+	}
+
+	// Add the db.import to the import paths.
+	if dbImportPath, found := revel.Config.String("db.import"); found {
+		sourceInfo.InitImportPaths = append(sourceInfo.InitImportPaths, dbImportPath)
+	}
+
+	// Generate two source files.
+	templateArgs = map[string]interface{}{
+		"Controllers":    sourceInfo.ControllerSpecs(),
+		"ValidationKeys": sourceInfo.ValidationKeys,
+		"ImportPaths":    calcImportAliases(sourceInfo),
+		"TestSuites":     sourceInfo.TestSuites(),
+	}
+
+	return templateArgs, nil
+}
+
+func generate(mainDir string, templateArgs map[string]interface{}) {
+	genSource(mainDir, "main.go", MAIN, templateArgs)
+	genSource("app/routes", "routes.go", ROUTES, templateArgs)
+}
+
 // Try to define a version string for the compiled app
 // The following is tried (first match returns):
 // - Read a version explicitly specified in the APP_VERSION environment
@@ -170,7 +204,7 @@ func cleanSource(dirs ...string) {
 
 func cleanDir(dir string) {
 	revel.INFO.Println("Cleaning dir " + dir)
-	tmpPath := path.Join(revel.AppPath, dir)
+	tmpPath := path.Join(revel.BasePath, dir)
 	f, err := os.Open(tmpPath)
 	if err != nil {
 		revel.ERROR.Println("Failed to clean dir:", err)
@@ -198,7 +232,6 @@ func cleanDir(dir string) {
 	}
 }
 
-
 // genSource renders the given template to produce source code, which it writes
 // to the given directory and file.
 func genSource(dir, filename, templateSource string, args map[string]interface{}) {
@@ -208,7 +241,7 @@ func genSource(dir, filename, templateSource string, args map[string]interface{}
 
 	// Create a fresh dir.
 	cleanSource(dir)
-	tmpPath := path.Join(revel.AppPath, dir)
+	tmpPath := path.Join(revel.BasePath, dir)
 	err := os.Mkdir(tmpPath, 0777)
 	if err != nil && !os.IsExist(err) {
 		revel.ERROR.Fatalf("Failed to make '%v' directory: %v", dir, err)
@@ -354,8 +387,13 @@ import (
 var (
 	runMode    *string = flag.String("runMode", "", "Run mode.")
 	port       *int    = flag.Int("port", 0, "By default, read from app.conf")
+	{{ if .initDirectly }}
+	basePath     *string = flag.String("basePath", "", "Path to the app folder.")
+  revelSrcPath *string = flag.String("revelSrcPath", "", "Path to the source root for Revel.")
+  {{ else }}
 	importPath *string = flag.String("importPath", "", "Go Import Path for the app.")
 	srcPath    *string = flag.String("srcPath", "", "Path to the source root.")
+  {{ end }}
 
 	// So compiler won't complain if the generated code doesn't reference reflect package...
 	_ = reflect.Invalid
@@ -363,7 +401,12 @@ var (
 
 func main() {
 	flag.Parse()
+
+	{{ if .initDirectly }}
+	revel.InitDirectly(*runMode, *revelSrcPath, *basePath)
+	{{ else }}
 	revel.Init(*runMode, *importPath, *srcPath)
+	{{ end }}
 	revel.INFO.Println("Running revel server")
 	{{range $i, $c := .Controllers}}
 	revel.RegisterController((*{{index $.ImportPaths .ImportPath}}.{{.StructName}})(nil),

--- a/revel/build.go
+++ b/revel/build.go
@@ -82,7 +82,7 @@ func buildApp(args []string) {
 			if moduleImportPath == "" {
 				continue
 			}
-			modulePath, err := revel.ResolveImportPath(moduleImportPath)
+			modulePath, err := revel.ResolveImportPath(srcPath, moduleImportPath)
 			if err != nil {
 				revel.ERROR.Fatalln("Failed to load module %s: %s", key[len("module."):], err)
 			}

--- a/revel/generate.go
+++ b/revel/generate.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/revel/cmd/harness"
+	"github.com/revel/revel"
+)
+
+var cmdGenerate = &Command{
+	UsageLine: "generate [import path] [command path]",
+	Short:     "generate a Revel application's routes and main func",
+	Long: `
+Generates the source code a Revel application needs to run.
+This includes routing code (app/routes/routes.go) and the
+main func to run the app.
+
+Target path is a relative path from the root of your Revel app.
+
+The generated command is expected to be run with the BasePath
+and the Revel src path.
+
+For example:
+
+    revel generate github.com/revel/samples/chat cmd/chat
+`,
+}
+
+func init() {
+	cmdGenerate.Run = generateFiles
+}
+
+func generateFiles(args []string) {
+	if len(args) != 2 {
+		fmt.Fprintf(os.Stderr, "%s\n%s", cmdBuild.UsageLine, cmdBuild.Long)
+		return
+	}
+
+	appImportPath, destPath := args[0], args[1]
+	if !revel.Initialized {
+		revel.Init("", appImportPath, "")
+	}
+
+	reverr := harness.Generate(destPath, true)
+	panicOnError(reverr, "Failed to build")
+}

--- a/revel/rev.go
+++ b/revel/rev.go
@@ -4,7 +4,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/agtorre/gocolorize"
 	"io"
 	"math/rand"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/agtorre/gocolorize"
 )
 
 // Cribbed from the genius organization of the "go" command.
@@ -32,6 +33,7 @@ func (cmd *Command) Name() string {
 var commands = []*Command{
 	cmdNew,
 	cmdRun,
+	cmdGenerate,
 	cmdBuild,
 	cmdPackage,
 	cmdClean,


### PR DESCRIPTION
Right now `revel` has a two ways to package code:

1. `revel build` will build the binary
2. `revel package` will build it and zip it all up

This change proposes that a third option is necessary, and that's generating the source required to build and run a Revel application manually.

This commit splits the build command into two parts, one to generate the code, and one to build it. The code generation is exposed into its own command.

My particular use case was to deploy on Heroku, from source, with the default go buildpack.

This PR depends on https://github.com/revel/revel/pull/985 and assumes that code generation uses the `InitDirectly` method of initializing Revel.

Improvements I'd suggest overall to this, which I'm omitting presently due to time constraints:

1. Add this to the `build` command and use a flagSet to disambiguate usage
2. Normal build usage might be `revel build importPath -o binTargetPath`
3. Generate usage might be `revel build importPath -main cmd/my-app-name -initDirectly`

cc @brendensoares 

