### PR TITLE
Added support for excluding files from revel build

### DIFF
--- a/harness/reflect.go
+++ b/harness/reflect.go
@@ -25,7 +25,7 @@ type SourceInfo struct {
 	StructSpecs []*TypeInfo
 	// ValidationKeys provides a two-level lookup.  The keys are:
 	// 1. The fully-qualified function name,
-	//    e.g. "github.com/revel/revel/samples/chat/app/controllers.(*Application).Action"
+	//    e.g. "github.com/revel/samples/chat/app/controllers.(*Application).Action"
 	// 2. Within that func's file, the line number of the (overall) expression statement.
 	//    e.g. the line returned from runtime.Caller()
 	// The result of the lookup the name of variable being validated.
@@ -44,7 +44,7 @@ type SourceInfo struct {
 // TypeInfo summarizes information about a struct type in the app source code.
 type TypeInfo struct {
 	StructName  string // e.g. "Application"
-	ImportPath  string // e.g. "github.com/revel/revel/samples/chat/app/controllers"
+	ImportPath  string // e.g. "github.com/revel/samples/chat/app/controllers"
 	PackageName string // e.g. "controllers"
 	MethodSpecs []*MethodSpec
 

--- a/harness/reflect_test.go
+++ b/harness/reflect_test.go
@@ -139,13 +139,13 @@ func TestTypeExpr(t *testing.T) {
 }
 
 func TestProcessBookingSource(t *testing.T) {
-	revel.Init("prod", "github.com/revel/revel/samples/booking", "")
+	revel.Init("prod", "github.com/revel/samples/booking", "")
 	sourceInfo, err := ProcessSource([]string{revel.AppPath})
 	if err != nil {
 		t.Fatal("Failed to process booking source with error:", err)
 	}
 
-	CONTROLLER_PKG := "github.com/revel/revel/samples/booking/app/controllers"
+	CONTROLLER_PKG := "github.com/revel/samples/booking/app/controllers"
 	expectedControllerSpecs := []*TypeInfo{
 		{"GorpController", CONTROLLER_PKG, "controllers", nil, nil},
 		{"Application", CONTROLLER_PKG, "controllers", nil, nil},
@@ -177,7 +177,7 @@ NEXT_TEST:
 }
 
 func BenchmarkProcessBookingSource(b *testing.B) {
-	revel.Init("", "github.com/revel/revel/samples/booking", "")
+	revel.Init("", "github.com/revel/samples/booking", "")
 	revel.TRACE = log.New(ioutil.Discard, "", 0)
 	b.ResetTimer()
 

--- a/revel/build.go
+++ b/revel/build.go
@@ -22,7 +22,7 @@ WARNING: The target path will be completely deleted, if it already exists!
 
 For example:
 
-    revel build github.com/revel/revel/samples/chat /tmp/chat
+    revel build github.com/revel/samples/chat /tmp/chat
 `,
 }
 

--- a/revel/build.go
+++ b/revel/build.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path"
@@ -59,15 +60,34 @@ func buildApp(args []string) {
 	// - revel
 	// - app
 
+	// read the ignore list from .revelignore
+	ignoreGlobals := make([]string, 0)
+	if _, err := os.Stat(filepath.Join(revel.BasePath, ".revelignore")); err == nil {
+		f, err := os.Open(filepath.Join(revel.BasePath, ".revelignore"))
+		panicOnError(err, "Failed to open ignore file")
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			if glob := scanner.Text(); len(glob) > 0 && !strings.HasPrefix(glob, "#") {
+				ignoreGlobals = append(ignoreGlobals, glob)
+			}
+		}
+
+		panicOnError(scanner.Err(), "Failed to read ignore file")
+	} else if !os.IsNotExist(err) {
+		panicOnError(err, "Failed to stat ignore file")
+	}
+
 	// Revel and the app are in a directory structure mirroring import path
 	srcPath := path.Join(destPath, "src")
 	destBinaryPath := path.Join(destPath, filepath.Base(app.BinaryPath))
 	tmpRevelPath := path.Join(srcPath, filepath.FromSlash(revel.REVEL_IMPORT_PATH))
 	mustCopyFile(destBinaryPath, app.BinaryPath)
 	mustChmod(destBinaryPath, 0755)
-	mustCopyDir(path.Join(tmpRevelPath, "conf"), path.Join(revel.RevelPath, "conf"), nil)
-	mustCopyDir(path.Join(tmpRevelPath, "templates"), path.Join(revel.RevelPath, "templates"), nil)
-	mustCopyDir(path.Join(srcPath, filepath.FromSlash(appImportPath)), revel.BasePath, nil)
+	mustCopyDir(path.Join(tmpRevelPath, "conf"), path.Join(revel.RevelPath, "conf"), nil, nil)
+	mustCopyDir(path.Join(tmpRevelPath, "templates"), path.Join(revel.RevelPath, "templates"), nil, nil)
+	mustCopyDir(path.Join(srcPath, filepath.FromSlash(appImportPath)), revel.BasePath, ignoreGlobals, nil)
 
 	// Find all the modules used and copy them over.
 	config := revel.Config.Raw()
@@ -90,7 +110,7 @@ func buildApp(args []string) {
 		}
 	}
 	for importPath, fsPath := range modulePaths {
-		mustCopyDir(path.Join(srcPath, importPath), fsPath, nil)
+		mustCopyDir(path.Join(srcPath, importPath), fsPath, nil, nil)
 	}
 
 	tmplData, runShPath := map[string]interface{}{

--- a/revel/clean.go
+++ b/revel/clean.go
@@ -15,7 +15,7 @@ Clean the Revel web application named by the given import path.
 
 For example:
 
-    revel clean github.com/revel/revel/samples/chat
+    revel clean github.com/revel/samples/chat
 
 It removes the app/tmp directory.
 `,

--- a/revel/new.go
+++ b/revel/new.go
@@ -172,7 +172,7 @@ func copyNewAppFiles() {
 	err = os.MkdirAll(appPath, 0777)
 	panicOnError(err, "Failed to create directory "+appPath)
 
-	mustCopyDir(appPath, skeletonPath, map[string]interface{}{
+	mustCopyDir(appPath, skeletonPath, nil, map[string]interface{}{
 		// app.conf
 		"AppName":  appName,
 		"BasePath": basePath,

--- a/revel/package.go
+++ b/revel/package.go
@@ -17,7 +17,7 @@ This allows it to be deployed and run on a machine that lacks a Go installation.
 
 For example:
 
-    revel package github.com/revel/revel/samples/chat
+    revel package github.com/revel/samples/chat
 `,
 }
 

--- a/revel/run.go
+++ b/revel/run.go
@@ -14,7 +14,7 @@ Run the Revel web application named by the given import path.
 
 For example, to run the chat room sample application:
 
-    revel run github.com/revel/revel/samples/chat dev
+    revel run github.com/revel/samples/chat dev
 
 The run mode is used to select which set of app.conf configuration should
 apply and may be used to determine logic in the application itself.
@@ -23,7 +23,7 @@ Run mode defaults to "dev".
 
 You can set a port as an optional third parameter.  For example:
 
-    revel run github.com/revel/revel/samples/chat prod 8080`,
+    revel run github.com/revel/samples/chat prod 8080`,
 }
 
 func init() {

--- a/revel/test.go
+++ b/revel/test.go
@@ -23,7 +23,7 @@ Run all tests for the Revel app named by the given import path.
 
 For example, to run the booking sample application's tests:
 
-    revel test github.com/revel/revel/samples/booking dev
+    revel test github.com/revel/samples/booking dev
 
 The run mode is used to select which set of app.conf configuration should
 apply and may be used to determine logic in the application itself.

--- a/revel/test.go
+++ b/revel/test.go
@@ -62,7 +62,7 @@ func testApp(args []string) {
 	// Ensure that the testrunner is loaded in this mode.
 	testRunnerFound := false
 	for _, module := range revel.Modules {
-		if module.ImportPath == "github.com/revel/modules/testrunner" {
+		if module.ImportPath == revel.Config.StringDefault("module.testrunner", "github.com/revel/modules/testrunner") {
 			testRunnerFound = true
 			break
 		}


### PR DESCRIPTION
This PR is in response to https://github.com/revel/revel/issues/1047.

This rudimentary implementation allows a developer to place glob file
patterns in a `.revelignore` file in the root directory of their revel
project. All project files which match any pattern in the file will be
exluced from all `revel build` and `revel package` output.