### PR TITLE
Install package dependencies when building

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -80,6 +80,7 @@ func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
 		versionLinkerFlags := fmt.Sprintf("-X %s/app.APP_VERSION \"%s\"", revel.ImportPath, appVersion)
 		flags := []string{
 			"build",
+			"-i",
 			"-ldflags", versionLinkerFlags,
 			"-tags", buildTags,
 			"-o", binName}


### PR DESCRIPTION
This speeds up recurring compiles a lot.