### PR TITLE
Added support for excluding files from revel build

### DIFF
--- a/revel/build.go
+++ b/revel/build.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path"
@@ -59,15 +60,34 @@ func buildApp(args []string) {
 	// - revel
 	// - app
 
+	// read the ignore list from .revelignore
+	ignoreGlobals := make([]string, 0)
+	if _, err := os.Stat(filepath.Join(revel.BasePath, ".revelignore")); err == nil {
+		f, err := os.Open(filepath.Join(revel.BasePath, ".revelignore"))
+		panicOnError(err, "Failed to open ignore file")
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			if glob := scanner.Text(); len(glob) > 0 && !strings.HasPrefix(glob, "#") {
+				ignoreGlobals = append(ignoreGlobals, glob)
+			}
+		}
+
+		panicOnError(scanner.Err(), "Failed to read ignore file")
+	} else if !os.IsNotExist(err) {
+		panicOnError(err, "Failed to stat ignore file")
+	}
+
 	// Revel and the app are in a directory structure mirroring import path
 	srcPath := path.Join(destPath, "src")
 	destBinaryPath := path.Join(destPath, filepath.Base(app.BinaryPath))
 	tmpRevelPath := path.Join(srcPath, filepath.FromSlash(revel.REVEL_IMPORT_PATH))
 	mustCopyFile(destBinaryPath, app.BinaryPath)
 	mustChmod(destBinaryPath, 0755)
-	mustCopyDir(path.Join(tmpRevelPath, "conf"), path.Join(revel.RevelPath, "conf"), nil)
-	mustCopyDir(path.Join(tmpRevelPath, "templates"), path.Join(revel.RevelPath, "templates"), nil)
-	mustCopyDir(path.Join(srcPath, filepath.FromSlash(appImportPath)), revel.BasePath, nil)
+	mustCopyDir(path.Join(tmpRevelPath, "conf"), path.Join(revel.RevelPath, "conf"), nil, nil)
+	mustCopyDir(path.Join(tmpRevelPath, "templates"), path.Join(revel.RevelPath, "templates"), nil, nil)
+	mustCopyDir(path.Join(srcPath, filepath.FromSlash(appImportPath)), revel.BasePath, ignoreGlobals, nil)
 
 	// Find all the modules used and copy them over.
 	config := revel.Config.Raw()
@@ -90,7 +110,7 @@ func buildApp(args []string) {
 		}
 	}
 	for importPath, fsPath := range modulePaths {
-		mustCopyDir(path.Join(srcPath, importPath), fsPath, nil)
+		mustCopyDir(path.Join(srcPath, importPath), fsPath, nil, nil)
 	}
 
 	tmplData, runShPath := map[string]interface{}{

--- a/revel/new.go
+++ b/revel/new.go
@@ -172,7 +172,7 @@ func copyNewAppFiles() {
 	err = os.MkdirAll(appPath, 0777)
 	panicOnError(err, "Failed to create directory "+appPath)
 
-	mustCopyDir(appPath, skeletonPath, map[string]interface{}{
+	mustCopyDir(appPath, skeletonPath, nil, map[string]interface{}{
 		// app.conf
 		"AppName":  appName,
 		"BasePath": basePath,


### PR DESCRIPTION
This PR is in response to https://github.com/revel/revel/issues/1047.

This rudimentary implementation allows a developer to place glob file
patterns in a `.revelignore` file in the root directory of their revel
project. All project files which match any pattern in the file will be
exluced from all `revel build` and `revel package` output.
