### PR TITLE
Revel run cmd become more robust

### DIFF
--- a/revel/util.go
+++ b/revel/util.go
@@ -8,6 +8,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
+	"go/build"
 	"io"
 	"os"
 	"path/filepath"
@@ -166,4 +167,10 @@ func empty(dirname string) bool {
 	}()
 	results, _ := dir.Readdir(1)
 	return len(results) == 0
+}
+
+func importPathFromCurrentDir() string {
+	pwd, _ := os.Getwd()
+	importPath, _ := filepath.Rel(filepath.Join(build.Default.GOPATH, "src"), pwd)
+	return filepath.ToSlash(importPath)
 }


### PR DESCRIPTION
As proposed in revel/revel#389 also `run` much improved with following-
* First thing `revel run` can detect import path from current directory
* `revel run` brings following combination
  * `revel run import-path run-mode port`
  * `revel run import-path run-mode`
  * `revel run import-path port`
  * `revel run run-mode port`
  * `revel run import-path`
  * `revel run run-mode`
  * `revel run port`
  * `revel run`

Whichever is not supplied will default to already know values of Revel.