### PR TITLE
Fixes issue #77 (regression bug when running `revel run appname`)

### DIFF
--- a/revel/run.go
+++ b/revel/run.go
@@ -5,8 +5,8 @@
 package main
 
 import (
+	"go/build"
 	"strconv"
-	"strings"
 
 	"github.com/revel/cmd/harness"
 	"github.com/revel/revel"
@@ -65,14 +65,18 @@ func parseRunArgs(args []string) *RunArgs {
 		// 1. revel run [import-path] [run-mode]
 		// 2. revel run [import-path] [port]
 		// 3. revel run [run-mode] [port]
-		if strings.Contains(args[0], "/") {
+		if _, err := build.Import(args[0], "", build.FindOnly); err == nil {
+			// 1st arg is the import path
 			inputArgs.ImportPath = args[0]
 			if port, err := strconv.Atoi(args[1]); err == nil {
+				// 2nd arg is the port number
 				inputArgs.Port = port
 			} else {
+				// 2nd arg is the run mode
 				inputArgs.Mode = args[1]
 			}
 		} else {
+			// 1st arg is the run mode
 			port, err := strconv.Atoi(args[1])
 			if err != nil {
 				errorf("Failed to parse port as integer: %s", args[1])
@@ -85,12 +89,14 @@ func parseRunArgs(args []string) *RunArgs {
 		// 1. revel run [import-path]
 		// 2. revel run [port]
 		// 3. revel run [run-mode]
-		if strings.Contains(args[0], "/") ||
-			strings.Contains(inputArgs.ImportPath, "..") {
+		if _, err := build.Import(args[0], "", build.FindOnly); err == nil {
+			// 1st arg is the import path
 			inputArgs.ImportPath = args[0]
 		} else if port, err := strconv.Atoi(args[0]); err == nil {
+			// 1st arg is the port number
 			inputArgs.Port = port
 		} else {
+			// 1st arg is the run mode
 			inputArgs.Mode = args[0]
 		}
 	}


### PR DESCRIPTION
It would be ideal to add functional tests to cover this scenario, but we don't have any in this repo.

The following is my history from the `HEAD~` version to my fix for #77:

```bash
brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel new hello
~
~ revel! http://revel.github.io
~
Your application is ready:
   /Users/brenden/.gvm/pkgsets/go1.7/global/src/hello

You can run it with:
   revel run hello

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run hello
~
~ revel! http://revel.github.io
~
ERROR 2017/03/24 20:37:06 revel.go:312: Failed to import . with error: import ".": import relative to unknown directory

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run hello/
~
~ revel! http://revel.github.io
~
INFO  2017/03/24 20:37:18 revel.go:365: Loaded module testrunner
INFO  2017/03/24 20:37:18 revel.go:365: Loaded module static
INFO  2017/03/24 20:37:18 revel.go:230: Initialized Revel v0.14.0 (2017-03-24) for >= go1.4
INFO  2017/03/24 20:37:18 run.go:113: Running hello (hello) in dev mode
INFO  2017/03/24 20:37:18 harness.go:175: Listening on :9000
^C
brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run hello/ prod
~
~ revel! http://revel.github.io
~
Listening on :9000...
^C

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run hello prod
~
~ revel! http://revel.github.io
~
Failed to parse port as integer: prod

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run hello 9001
~
~ revel! http://revel.github.io
~
ERROR 2017/03/24 20:37:51 revel.go:312: Failed to import . with error: import ".": import relative to unknown directory

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run hello/ 9001
~
~ revel! http://revel.github.io
~
INFO  2017/03/24 20:38:02 revel.go:365: Loaded module testrunner
INFO  2017/03/24 20:38:02 revel.go:365: Loaded module static
INFO  2017/03/24 20:38:02 revel.go:230: Initialized Revel v0.14.0 (2017-03-24) for >= go1.4
INFO  2017/03/24 20:38:02 run.go:113: Running hello (hello) in dev mode
INFO  2017/03/24 20:38:02 harness.go:175: Listening on :9001
^C
brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ go install github.com/revel/cmd/revel
# github.com/revel/cmd/revel
github.com/revel/cmd/revel/run.go:10: imported and not used: "strings"

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ go install github.com/revel/cmd/revel

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run hello 9001
~
~ revel! http://revel.github.io
~
INFO  2017/03/24 20:38:33 revel.go:365: Loaded module testrunner
INFO  2017/03/24 20:38:33 revel.go:365: Loaded module static
INFO  2017/03/24 20:38:33 revel.go:230: Initialized Revel v0.14.0 (2017-03-24) for >= go1.4
INFO  2017/03/24 20:38:33 run.go:119: Running hello (hello) in dev mode
INFO  2017/03/24 20:38:33 harness.go:175: Listening on :9001
^C
brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run hello prod
~
~ revel! http://revel.github.io
~
Listening on :9000...
^C

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run hello/ prod
~
~ revel! http://revel.github.io
~
Listening on :9000...
^C

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run  prod
~
~ revel! http://revel.github.io
~
ERROR 2017/03/24 20:38:51 revel.go:312: Failed to import . with error: import ".": import relative to unknown directory

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ revel run
~
~ revel! http://revel.github.io
~
ERROR 2017/03/24 20:38:56 revel.go:312: Failed to import . with error: import ".": import relative to unknown directory

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src
$ cd hello/

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src/hello
$ revel run
~
~ revel! http://revel.github.io
~
INFO  2017/03/24 20:38:59 revel.go:365: Loaded module testrunner
INFO  2017/03/24 20:38:59 revel.go:365: Loaded module static
INFO  2017/03/24 20:38:59 revel.go:230: Initialized Revel v0.14.0 (2017-03-24) for >= go1.4
INFO  2017/03/24 20:38:59 run.go:119: Running hello (hello) in dev mode
INFO  2017/03/24 20:38:59 harness.go:175: Listening on :9000
^C
brenden at slate in ~/.gvm/pkgsets/go1.7/global/src/hello
$ cd app

brenden at slate in ~/.gvm/pkgsets/go1.7/global/src/hello/app
$ revel run
~
~ revel! http://revel.github.io
~
2017/03/24 20:39:13 revel.go:183: app.conf: No mode found: dev
```