### PR TITLE
Makes it so harness can bootstrap using the new GoRequest / response …

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -286,7 +286,7 @@ func calcImportAliases(src *SourceInfo) map[string]string {
 }
 
 func addAlias(aliases map[string]string, importPath, pkgName string) {
-	alias, ok := aliases[importPath]
+    alias, ok := aliases[importPath]
 	if ok {
 		return
 	}
@@ -297,7 +297,7 @@ func addAlias(aliases map[string]string, importPath, pkgName string) {
 func makePackageAlias(aliases map[string]string, pkgName string) string {
 	i := 0
 	alias := pkgName
-	for containsValue(aliases, alias) {
+	for containsValue(aliases, alias) || alias=="revel" {
 		alias = fmt.Sprintf("%s%d", pkgName, i)
 		i++
 	}

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -47,7 +47,10 @@ type Harness struct {
 	proxy      *httputil.ReverseProxy
 }
 
-func renderError(w http.ResponseWriter, r *http.Request, err error) {
+func renderError(iw http.ResponseWriter, ir *http.Request, err error) {
+    r,w := &revel.GORequest{Goheader:&revel.GOHeader{}}, &revel.GOResponse{Goheader:&revel.GOHeader{}}
+    r.Set(ir)
+    w.Set(iw)
 	req, resp := revel.NewRequest(r), revel.NewResponse(w)
 	c := revel.NewController(req, resp)
 	c.RenderError(err).Apply(req, resp)


### PR DESCRIPTION
Makes it so harness can bootstrap using the new GoRequest / response wrappers,
also fixes a bug with revel importing the revel package