### PR TITLE
Revamped engine to reduce the interface size.

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -48,12 +48,11 @@ type Harness struct {
 }
 
 func renderError(iw http.ResponseWriter, ir *http.Request, err error) {
-    r,w := &revel.GORequest{Goheader:&revel.GOHeader{}}, &revel.GOResponse{Goheader:&revel.GOHeader{}}
-    r.Set(ir)
-    w.Set(iw)
-	req, resp := revel.NewRequest(r), revel.NewResponse(w)
-	c := revel.NewController(req, resp)
-	c.RenderError(err).Apply(req, resp)
+	context := revel.NewGOContext(nil)
+	context.Request.SetRequest(ir)
+	context.Response.SetResponse(iw)
+	c := revel.NewController(context)
+	c.RenderError(err).Apply(c.Request, c.Response)
 }
 
 // ServeHTTP handles all requests.

--- a/revel/skeleton/app/init.go
+++ b/revel/skeleton/app/init.go
@@ -43,9 +43,9 @@ func init() {
 // should probably also have a filter for CSRF
 // not sure if it can go in the same filter or not
 var HeaderFilter = func(c *revel.Controller, fc []revel.Filter) {
-	c.Response.Out.Header().Add("X-Frame-Options", "SAMEORIGIN")
-	c.Response.Out.Header().Add("X-XSS-Protection", "1; mode=block")
-	c.Response.Out.Header().Add("X-Content-Type-Options", "nosniff")
+	c.Response.SetHeader("X-Frame-Options", "SAMEORIGIN")
+	c.Response.SetHeader("X-XSS-Protection", "1; mode=block")
+	c.Response.SetHeader( "X-Content-Type-Options", "nosniff")
 
 	fc[0](c, fc[1:]) // Execute the next filter stage.
 }


### PR DESCRIPTION
Added BufferedServerHeader to CompressWriter to prevent header from writing out immediately
Reduced object stack to a single controller stack which has the request and response objects already instaniated in it
Fixed go engine to match new spec
Modified code to make use of the Request object to access the ServerEngine (allows caching of ServerHeader and ResponseWriter)
Modified simple stack to add an upper bounds to the number of objects in cache, any more objects then the upper bounds will be left to garbage collect