### PR TITLE
Logging error added more compile warnings

### DIFF
--- a/harness/app.go
+++ b/harness/app.go
@@ -60,9 +60,9 @@ func NewAppCmd(binPath string, port int) AppCmd {
 func (cmd AppCmd) Start() error {
 	listeningWriter := &startupListeningWriter{os.Stdout, make(chan bool)}
 	cmd.Stdout = listeningWriter
-	revel.RevelLog.Debug("Exec app:","path", cmd.Path,"args", cmd.Args)
+	revel.RevelLog.Debug("Exec app:", "path", cmd.Path, "args", cmd.Args)
 	if err := cmd.Cmd.Start(); err != nil {
-		revel.RevelLog.Fatal("Error running:","error", err)
+		revel.RevelLog.Fatal("Error running:", "error", err)
 	}
 
 	select {
@@ -70,7 +70,7 @@ func (cmd AppCmd) Start() error {
 		return errors.New("revel/harness: app died")
 
 	case <-time.After(30 * time.Second):
-		revel.RevelLog.Debug("Killing revel server process did not respond after wait timeout", cmd.Process.Pid)
+		revel.RevelLog.Debug("Killing revel server process did not respond after wait timeout", "processid", cmd.Process.Pid)
 		cmd.Kill()
 		return errors.New("revel/harness: app timed out")
 
@@ -84,19 +84,19 @@ func (cmd AppCmd) Start() error {
 
 // Run the app server inline.  Never returns.
 func (cmd AppCmd) Run() {
-	revel.RevelLog.Debug("Exec app:","path", cmd.Path,"args", cmd.Args)
+	revel.RevelLog.Debug("Exec app:", "path", cmd.Path, "args", cmd.Args)
 	if err := cmd.Cmd.Run(); err != nil {
-		revel.RevelLog.Fatal("Error running:","error", err)
+		revel.RevelLog.Fatal("Error running:", "error", err)
 	}
 }
 
 // Kill terminates the app server if it's running.
 func (cmd AppCmd) Kill() {
 	if cmd.Cmd != nil && (cmd.ProcessState == nil || !cmd.ProcessState.Exited()) {
-		revel.RevelLog.Debug("Killing revel server pid","pid", cmd.Process.Pid)
+		revel.RevelLog.Debug("Killing revel server pid", "pid", cmd.Process.Pid)
 		err := cmd.Process.Kill()
 		if err != nil {
-			revel.RevelLog.Fatal("Failed to kill revel server:","error", err)
+			revel.RevelLog.Fatal("Failed to kill revel server:", "error", err)
 		}
 	}
 }

--- a/harness/build.go
+++ b/harness/build.go
@@ -393,7 +393,7 @@ var (
 func main() {
 	flag.Parse()
 	revel.Init(*runMode, *importPath, *srcPath)
-	revel.INFO.Println("Running revel server")
+	revel.AppLog.Info("Running revel server")
 	{{range $i, $c := .Controllers}}
 	revel.RegisterController((*{{index $.ImportPaths .ImportPath}}.{{.StructName}})(nil),
 		[]*revel.MethodType{

--- a/revel/run.go
+++ b/revel/run.go
@@ -91,7 +91,7 @@ func parseRunArgs(args []string) *RunArgs {
 		// 3. revel run [run-mode]
 		_, err := build.Import(args[0], "", build.FindOnly)
 		if err != nil {
-			revel.WARN.Printf("Unable to run using an import path, assuming import path is working directory %s %s", args[0], err.Error())
+			revel.RevelLog.Warn("Unable to run using an import path, assuming import path is working directory %s %s", "Argument", args[0], "error", err.Error())
 		}
 		println("Trying to build with", args[0], err)
 		if err == nil {
@@ -121,18 +121,18 @@ func runApp(args []string) {
 		runArgs.Port = revel.HTTPPort
 	}
 
-	revel.INFO.Printf("Running %s (%s) in %s mode\n", revel.AppName, revel.ImportPath, runArgs.Mode)
-	revel.TRACE.Println("Base path:", revel.BasePath)
+	revel.RevelLog.Infof("Running %s (%s) in %s mode\n", revel.AppName, revel.ImportPath, runArgs.Mode)
+	revel.RevelLog.Debug("Base path:", "path", revel.BasePath)
 
 	// If the app is run in "watched" mode, use the harness to run it.
 	if revel.Config.BoolDefault("watch", true) && revel.Config.BoolDefault("watch.code", true) {
-		revel.TRACE.Println("Running in watched mode.")
+		revel.RevelLog.Debug("Running in watched mode.")
 		revel.HTTPPort = runArgs.Port
 		harness.NewHarness().Run() // Never returns.
 	}
 
 	// Else, just build and run the app.
-	revel.TRACE.Println("Running in live build mode.")
+	revel.RevelLog.Debug("Running in live build mode.")
 	app, err := harness.Build()
 	if err != nil {
 		errorf("Failed to build app: %s", err)

--- a/revel/skeleton/conf/app.conf.template
+++ b/revel/skeleton/conf/app.conf.template
@@ -170,13 +170,13 @@ module.testrunner = github.com/revel/modules/testrunner
 #   Log to Os's standard error output. Default value.
 # "relative/path/to/log"
 #   Log to file.
-log.all.filter.module.app = stdout # Log all loggers for the application to the stdout
-log.error.output = stderr          # Log all loggers for Revel errors to the stderr
+log.all.filter.module.app = stdout    # Log all loggers for the application to the stdout
+log.error.nfilter.module.app = stderr # Everything else that logs an error to stderr
 
 # Revel request access log
 # Access log line format:
 # INFO  21:53:55 static server-engine.go:169: Request Stats                             ip=127.0.0.1 path=/public/vendors/datatables.net-buttons/js/buttons.html5.min.js method=GET start=2017/08/31 21:53:55 status=200 duration_seconds=0.0002583 section=requestlog
-log.request.output = stderr
+log.request.output = stdout
 
 
 
@@ -199,9 +199,7 @@ module.testrunner =
 log.warn.output  = log/%(app.name)s.log  # Log all loggers for the application to the stdout
 log.error.output = log/%(app.name)s.log            # Log all errors to the stdout
 
-# Revel request access log
-# Access log line format:
-# INFO  21:53:55 static server-engine.go:169: Request Stats                             ip=127.0.0.1 path=/public/vendors/datatables.net-buttons/js/buttons.html5.min.js method=GET start=2017/08/31 21:53:55 status=200 duration_seconds=0.0002583 section=requestlog
+# Revel request access log (json format)
 # Example:
 #   log.request.output = %(app.name)s-request.json
-log.request.output = log/requests.json
+log.request.output = log/%(app.name)s-requests.json


### PR DESCRIPTION
Fixed missing debug context parameter name
Added check to see if specification was not exported
Added warnings if expected types did not match specification


I have added some code to detect and hide types that are unexported
```
DEBUG 13:14:00  revel reflect.go:704: Skipping adding spec for unexported type  type=test package=web/app/controllers 
```
I have added some warnings to indicate if a type exists in the package but does not inherit from the expected package like
```
WARN  11:54:39  revel reflect.go:713: Type found in package: controllers, but did not inherit from: revel.Controller  name=EventUI path=web/app/controllers                       
```