### PR TITLE
Generate same value of AppVersion regardless of where revel is run

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -39,7 +39,7 @@ func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
 
 	// Add the db.import to the import paths.
 	if dbImportPath, found := revel.Config.String("db.import"); found {
-		sourceInfo.InitImportPaths = append(sourceInfo.InitImportPaths, strings.Split(dbImportPath,",")...)
+		sourceInfo.InitImportPaths = append(sourceInfo.InitImportPaths, strings.Split(dbImportPath, ",")...)
 	}
 
 	// Generate two source files.
@@ -210,7 +210,7 @@ func getAppVersion() string {
 		if (err != nil && os.IsNotExist(err)) || !info.IsDir() {
 			return ""
 		}
-		gitCmd := exec.Command(gitPath, "--git-dir="+gitDir, "describe", "--always", "--dirty")
+		gitCmd := exec.Command(gitPath, "--git-dir="+gitDir, "--work-tree="+revel.BasePath, "describe", "--always", "--dirty")
 		revel.RevelLog.Debug("Exec:", "args", gitCmd.Args)
 		output, err := gitCmd.Output()
 


### PR DESCRIPTION
Explicitly set the --work-tree path for the git command when retrieving the commit hash, to avoid always getting the '-dirty' suffix added to the AppVersion when revel is **not** run in the the app base directory. Use the revel.BasePath property to let git know which work tree to use.

gofmt causes more changes (line 42). The relevant changes however are restricted to line 213.