### PR TITLE
Add generate go files and support building outside GOPATH.

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -23,18 +23,17 @@ import (
 
 var importErrorPattern = regexp.MustCompile("cannot find package \"([^\"]+)\"")
 
-// Build the app:
-// 1. Generate the the main.go file.
-// 2. Run the appropriate "go build" command.
-// Requires that revel.Init has been called previously.
-// Returns the path to the built binary, and an error if there was a problem building it.
-func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
+// Generate routes.go and main.go files by walking over the project folder.
+// Supports generating if project is not organized in GOPATH. If outside
+// GOPATH, import paths might have to be rewritten. Use find and replace args
+// to adjust.
+func GenerateRoutesMain(codePaths []string, outsideGopath bool, find, replace string) (compileError *revel.Error) {
 	// First, clear the generated files (to avoid them messing with ProcessSource).
 	cleanSource("tmp", "routes")
 
-	sourceInfo, compileError := ProcessSource(revel.CodePaths)
+	sourceInfo, compileError := ProcessSource(codePaths, outsideGopath)
 	if compileError != nil {
-		return nil, compileError
+		return compileError
 	}
 
 	// Add the db.import to the import paths.
@@ -49,9 +48,38 @@ func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
 		"ImportPaths":    calcImportAliases(sourceInfo),
 		"TestSuites":     sourceInfo.TestSuites(),
 	}
+
+	// If the project is outside of the GOPATH, rewrite new import paths.
+	if outsideGopath {
+		oldImportPaths := templateArgs["ImportPaths"]
+		newImportPaths := make(map[string]string)
+		switch v := oldImportPaths.(type) {
+		case map[string]string:
+			for fullImport, shortImport := range v {
+				newFullImport := strings.Replace(fullImport, find, replace, 1)
+				newImportPaths[newFullImport] = shortImport
+			}
+		default:
+			revel.ERROR.Fatalln("Import paths expected to be a map[string]string")
+		}
+
+		templateArgs["NewImportPaths"] = newImportPaths
+	} else {
+		templateArgs["NewImportPaths"] = templateArgs["ImportPaths"]
+	}
+
 	genSource("tmp", "main.go", RevelMainTemplate, templateArgs)
 	genSource("routes", "routes.go", RevelRoutesTemplate, templateArgs)
+	return
+}
 
+// Build the app: Run the appropriate "go build" command.
+// Requires that revel.Init has been called previously.
+// Returns the path to the built binary, and an error if there was a problem building it.
+func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
+	if compileError = GenerateRoutesMain(revel.CodePaths, false, "", ""); compileError != nil {
+		return nil, compileError
+	}
 	// Read build config.
 	buildTags := revel.Config.StringDefault("build.tags", "")
 
@@ -418,7 +446,7 @@ package main
 import (
 	"flag"
 	"reflect"
-	"github.com/revel/revel"{{range $k, $v := $.ImportPaths}}
+	"github.com/revel/revel"{{range $k, $v := $.NewImportPaths}}
 	{{$v}} "{{$k}}"{{end}}
 	"github.com/revel/revel/testing"
 )

--- a/harness/reflect.go
+++ b/harness/reflect.go
@@ -86,20 +86,26 @@ type embeddedTypeName struct {
 // receiver.
 type methodMap map[string][]*MethodSpec
 
-// ProcessSource parses the app controllers directory and
-// returns a list of the controller types found.
-// Otherwise CompileError if the parsing fails.
-func ProcessSource(roots []string) (*SourceInfo, *revel.Error) {
+// ProcessSource parses the app controllers directory and returns a list of the
+// controller types found.  Otherwise CompileError if the parsing fails.  Add
+// optional boolean for parsing code outside the GOPATH
+func ProcessSource(roots []string, outsideGopath bool) (*SourceInfo, *revel.Error) {
 	var (
 		srcInfo      *SourceInfo
 		compileError *revel.Error
 	)
 
 	for _, root := range roots {
-		rootImportPath := importPathFromPath(root)
-		if rootImportPath == "" {
-			revel.RevelLog.Warn("Skipping empty code path", "path", root)
-			continue
+		var rootImportPath string
+		if outsideGopath {
+			// Building outside GOPATH, so set root of import path to self.
+			rootImportPath = root
+		} else {
+			rootImportPath = importPathFromPath(root)
+			if rootImportPath == "" {
+				revel.WARN.Println("Skipping code path", root)
+				continue
+			}
 		}
 
 		// Start walking the directory tree.
@@ -182,7 +188,7 @@ func ProcessSource(roots []string) (*SourceInfo, *revel.Error) {
 				pkg = v
 			}
 
-			srcInfo = appendSourceInfo(srcInfo, processPackage(fset, pkgImportPath, path, pkg))
+			srcInfo = appendSourceInfo(srcInfo, processPackage(fset, pkgImportPath, path, pkg, outsideGopath))
 			return nil
 		})
 	}
@@ -207,7 +213,7 @@ func appendSourceInfo(srcInfo1, srcInfo2 *SourceInfo) *SourceInfo {
 	return srcInfo1
 }
 
-func processPackage(fset *token.FileSet, pkgImportPath, pkgPath string, pkg *ast.Package) *SourceInfo {
+func processPackage(fset *token.FileSet, pkgImportPath, pkgPath string, pkg *ast.Package, outsideGopath bool) *SourceInfo {
 	var (
 		structSpecs     []*TypeInfo
 		initImportPaths []string
@@ -229,7 +235,7 @@ func processPackage(fset *token.FileSet, pkgImportPath, pkgPath string, pkg *ast
 
 		// For each declaration in the source file...
 		for _, decl := range file.Decls {
-			addImports(imports, decl, pkgPath)
+			addImports(imports, decl, pkgPath, outsideGopath)
 
 			if scanControllers {
 				// Match and add both structs and methods
@@ -283,7 +289,7 @@ func getFuncName(funcDecl *ast.FuncDecl) string {
 	return prefix + funcDecl.Name.Name
 }
 
-func addImports(imports map[string]string, decl ast.Decl, srcDir string) {
+func addImports(imports map[string]string, decl ast.Decl, srcDir string, outsideGopath bool) {
 	genDecl, ok := decl.(*ast.GenDecl)
 	if !ok {
 		return
@@ -314,14 +320,24 @@ func addImports(imports map[string]string, decl ast.Decl, srcDir string) {
 		if pkgAlias == "" {
 			pkg, err := build.Import(fullPath, srcDir, 0)
 			if err != nil {
-				// We expect this to happen for apps using reverse routing (since we
-				// have not yet generated the routes).  Don't log that.
-				if !strings.HasSuffix(fullPath, "/app/routes") {
-					revel.RevelLog.Debug("Could not find import:", "path", fullPath)
+				// If building outside default Gopath or without it set, then cannot rely on build
+				// Import tool to provide the correct name.
+				if !outsideGopath {
+					// We expect this to happen for apps using reverse routing (since we
+					// have not yet generated the routes).  Don't log that.
+					if !strings.HasSuffix(fullPath, "/app/routes") {
+						revel.TRACE.Println("Could not find import:", fullPath)
+					}
+					continue
 				}
-				continue
 			}
 			pkgAlias = pkg.Name
+
+			// Instead let's just take the final name after the last slash
+			if outsideGopath {
+				splitPkgPath := strings.Split(fullPath, "/")
+				pkgAlias = splitPkgPath[len(splitPkgPath)-1]
+			}
 		}
 
 		imports[pkgAlias] = fullPath

--- a/revel/generate.go
+++ b/revel/generate.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2012-2016 The Revel Framework Authors, All rights reserved.
+// Revel Framework source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/revel/cmd/harness"
+	"github.com/revel/revel"
+)
+
+var cmdGenerate = &Command{
+	UsageLine: "generate [import path] [source path] [find] [replace]",
+	Short:     "Generate the routes and main.go files",
+	Long: `
+Generate the routes and main.go files for a revel project.
+
+This is necessary to build applications that are not organized in the default
+GOPATH. Because we may not be in the default GOPATH, some of the imports in
+main.go may have to be rewritten. Use the optional find and replace to do this.
+
+WARNING: the app/routes and app/tmp directories will be deleted.
+
+For example:
+
+    revel generate github.com/revel/examples/chat ./
+
+    revel generate revel/examples/chat ./ revel/examples github.com/revel/examples
+`,
+}
+
+func init() {
+	cmdGenerate.Run = generateRoutesMain
+}
+
+func generateRoutesMain(args []string) {
+	if len(args) < 2 {
+		errMsg := "Import and source paths are required."
+		fmt.Fprintf(os.Stderr, "%s\n%s\n%s", errMsg, cmdGenerate.UsageLine, cmdGenerate.Long)
+		return
+	}
+
+	appImportPath, srcPath := args[0], args[1]
+
+	var find, replace string
+	if len(args) >= 3 {
+		if len(args) < 4 {
+			errMsg := "Specify a replacement string if find string specified."
+			fmt.Fprintf(os.Stderr, "%s\n%s\n%s", errMsg, cmdBuild.UsageLine, cmdBuild.Long)
+			return
+		}
+		find, replace = args[2], args[3]
+	}
+
+	if !revel.Initialized {
+		revel.Init("", appImportPath, srcPath)
+	}
+
+	reverr := harness.GenerateRoutesMain(revel.CodePaths, true, find, replace)
+	panicOnError(reverr, "Failed to generate files")
+}

--- a/revel/rev.go
+++ b/revel/rev.go
@@ -51,6 +51,7 @@ var commands = []*Command{
 	cmdClean,
 	cmdTest,
 	cmdVersion,
+	cmdGenerate,
 }
 
 func main() {


### PR DESCRIPTION
For revel projects that are organized outside the traditional GOPATH,
these changes support generating the routes and main.go files.
Additionally, it ensures that the import paths generated are correct if
we cannot use the go/build tools to find them.