### PR TITLE
Adding referrer policy security header

### DIFF
--- a/revel/skeleton/app/init.go
+++ b/revel/skeleton/app/init.go
@@ -44,6 +44,7 @@ var HeaderFilter = func(c *revel.Controller, fc []revel.Filter) {
 	c.Response.Out.Header().Add("X-Frame-Options", "SAMEORIGIN")
 	c.Response.Out.Header().Add("X-XSS-Protection", "1; mode=block")
 	c.Response.Out.Header().Add("X-Content-Type-Options", "nosniff")
+	c.Response.Out.Header().Add("Referrer-Policy", "strict-origin-when-cross-origin")
 
 	fc[0](c, fc[1:]) // Execute the next filter stage.
 }


### PR DESCRIPTION
It will set a default strict Referrer-Policy ``strict-origin-when-cross-origin`` that controls what referrer information shall be included with requests.
More: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy, https://scotthelme.co.uk/a-new-security-header-referrer-policy/
It can prevent issues like: https://robots.thoughtbot.com/is-your-site-leaking-password-reset-links
  