### PR TITLE
add support to map as a argument in the controller action

### DIFF
--- a/harness/reflect.go
+++ b/harness/reflect.go
@@ -17,8 +17,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/revel/revel"
 	"unicode"
+
+	"github.com/revel/revel"
 )
 
 // SourceInfo is the top-level struct containing all extracted information
@@ -782,6 +783,13 @@ func NewTypeExpr(pkgName string, expr ast.Expr) TypeExpr {
 	case *ast.ArrayType:
 		e := NewTypeExpr(pkgName, t.Elt)
 		return TypeExpr{"[]" + e.Expr, e.PkgName, e.pkgIndex + 2, e.Valid}
+	case *ast.MapType:
+		if identKey, ok := t.Key.(*ast.Ident); ok && IsBuiltinType(identKey.Name) {
+			e := NewTypeExpr(pkgName, t.Value)
+			return TypeExpr{"map[" + identKey.Name + "]" + e.Expr, e.PkgName, e.pkgIndex + len("map["+identKey.Name+"]"), e.Valid}
+		}
+
+		revel.RevelLog.Error("Failed to generate name for field. Make sure the field name is valid.")
 	case *ast.Ellipsis:
 		e := NewTypeExpr(pkgName, t.Elt)
 		return TypeExpr{"[]" + e.Expr, e.PkgName, e.pkgIndex + 2, e.Valid}

--- a/harness/reflect_test.go
+++ b/harness/reflect_test.go
@@ -94,18 +94,20 @@ func TestGetValidationKeys(t *testing.T) {
 }
 
 var TypeExprs = map[string]TypeExpr{
-	"int":        {"int", "", 0, true},
-	"*int":       {"*int", "", 1, true},
-	"[]int":      {"[]int", "", 2, true},
-	"...int":     {"[]int", "", 2, true},
-	"[]*int":     {"[]*int", "", 3, true},
-	"...*int":    {"[]*int", "", 3, true},
-	"MyType":     {"MyType", "pkg", 0, true},
-	"*MyType":    {"*MyType", "pkg", 1, true},
-	"[]MyType":   {"[]MyType", "pkg", 2, true},
-	"...MyType":  {"[]MyType", "pkg", 2, true},
-	"[]*MyType":  {"[]*MyType", "pkg", 3, true},
-	"...*MyType": {"[]*MyType", "pkg", 3, true},
+	"int":             {"int", "", 0, true},
+	"*int":            {"*int", "", 1, true},
+	"[]int":           {"[]int", "", 2, true},
+	"...int":          {"[]int", "", 2, true},
+	"[]*int":          {"[]*int", "", 3, true},
+	"...*int":         {"[]*int", "", 3, true},
+	"MyType":          {"MyType", "pkg", 0, true},
+	"*MyType":         {"*MyType", "pkg", 1, true},
+	"[]MyType":        {"[]MyType", "pkg", 2, true},
+	"...MyType":       {"[]MyType", "pkg", 2, true},
+	"[]*MyType":       {"[]*MyType", "pkg", 3, true},
+	"...*MyType":      {"[]*MyType", "pkg", 3, true},
+	"map[int]MyType":  {"map[int]MyType", "pkg", 8, true},
+	"map[int]*MyType": {"map[int]*MyType", "pkg", 9, true},
 }
 
 func TestTypeExpr(t *testing.T) {


### PR DESCRIPTION
add support to map as a argument in the controller action

````go
func (c *MyController) Index(xx map[int]XXXX) revel.Result {
  xxxx
}
````