### PR TITLE
fix import path trimming during main.go generation

### DIFF
--- a/harness/reflect.go
+++ b/harness/reflect.go
@@ -821,9 +821,8 @@ func IsBuiltinType(name string) bool {
 }
 
 func importPathFromPath(root string) string {
-	vendoringPath := revel.BasePath + "/vendor/"
-	if strings.HasPrefix(root, vendoringPath) {
-		return filepath.ToSlash(root[len(vendoringPath):])
+	if vendorIdx := strings.Index(root, "/vendor/"); vendorIdx != -1 {
+		return filepath.ToSlash(root[vendorIdx+8:])
 	}
 	for _, gopath := range filepath.SplitList(build.Default.GOPATH) {
 		srcPath := filepath.Join(gopath, "src")


### PR DESCRIPTION
The `importPathFromPath` function invoked during `revel build`
in callchain `Build` -> `ProcessSource` ->  `importPathFromPath`
assumes that the vendor folder is in the app's root directory
when trimming import paths for inclusion into autogenerated
templates.

Consequently vendor detection fails if the vendor folder
is located at another higher layer in the directory tree
and /prefix/path/to/vendor/ is not stripped from the
import path, leading to inclusion of invalid importpaths,
resulting in compilation error and build abortion.

This fix makes the vendor folder detection more flexible,
allowing for the vendor folder to be present at any higher
level in the directory hirachy.