### PR TITLE
Drop support for golang 1.5 and support golang 1.10 in revel 0.14.x.

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -87,12 +87,6 @@ func Build(buildFlags ...string) (app *App, compileError *revel.Error) {
 		versionLinkerFlags := fmt.Sprintf("-X %s/app.AppVersion=%s -X %s/app.BuildTime=%s",
 			revel.ImportPath, appVersion, revel.ImportPath, buildTime)
 
-		// TODO remove version check for versionLinkerFlags after Revel becomes Go min version to go1.5
-		goVersion, _ := strconv.ParseFloat(runtime.Version()[2:5], 64)
-		if goVersion < 1.5 {
-			versionLinkerFlags = fmt.Sprintf("-X %s/app.AppVersion \"%s\" -X %s/app.BuildTime \"%s\"",
-				revel.ImportPath, appVersion, revel.ImportPath, buildTime)
-		}
 		flags := []string{
 			"build",
 			"-i",


### PR DESCRIPTION
I want to update to 0.18.x because 0.14.x doesn't work with golang 1.10 (and would be nice to update revel too).
However I'm having trouble with updating my code to revel 0.18.x (or 0.19.x too) because of the changes in handling websockets. I don't know how to access `*websocket.Conn` anymore and this is necessary for me to apply some custom changes to https://godoc.org/golang.org/x/net/websocket
The golang team implementation of websockets is pretty much broken, to the point they recommend using https://godoc.org/github.com/gorilla/websocket instead in their official doc https://godoc.org/golang.org/x/net/websocket:
>  This package currently lacks some features found in an alternative and more actively maintained WebSocket package:
>
> https://godoc.org/github.com/gorilla/websocket

The issues happens if you have lots of long running websockets, most of them you can mitigate with some custom changes starting with some as simple as setting [Conn.SetDeadline](https://godoc.org/golang.org/x/net/websocket#Conn.SetDeadline), reconnection support and ending with more complex like implementing keep-alive. However since we can't access `*websocket.Conn` anymore (if we can then please let me know how) then I can't fix those issues anymore, this means I can't really upgrade to never version of revel, but since I can't upgrade to never version of revel I can't also upgrade golang to 1.10.

Would it be possible to release 0.14.2 that fixes the issue with golang 1.10? I did this PR against release/v0.15.0 because there is no branch for 0.14.2 - once it's created I can rebase the PR. This would let us work with newest golang and upgrade to never revel at a later time when I will figure out how to handle better websocket connections (or maybe you also have plans to switch websocket library?).