### PR TITLE
Quick fix for test breaking with pongo2 templates.

### DIFF
--- a/revel/test.go
+++ b/revel/test.go
@@ -248,6 +248,7 @@ func getTestsList(baseURL string) (*[]controllers.TestSuiteDesc, error) {
 func runTestSuites(baseURL, resultPath string, testSuites *[]controllers.TestSuiteDesc) (*[]controllers.TestSuiteResult, bool) {
 	// Load the result template, which we execute for each suite.
 	module, _ := revel.ModuleByName("testrunner")
+	revel.Config.SetOption("template.engines", "go")
 	TemplateLoader := revel.NewTemplateLoader([]string{filepath.Join(module.Path, "app", "views")})
 	if err := TemplateLoader.Refresh(); err != nil {
 		errorf("Failed to compile templates: %s", err)


### PR DESCRIPTION
This isn't maybe a "proper" fix for the problem with testrunner clashing with pongo2 templates, but it's a quick fix and helps everyone that uses `go get` to install the Revel command line tool.

Confirmed to be working in my environment.
closes #126 