### PR TITLE
Run the app on a random port if port is set to zero

### DIFF
--- a/harness/app.go
+++ b/harness/app.go
@@ -31,6 +31,10 @@ func NewApp(binPath string) *App {
 
 // Cmd returns a command to run the app server using the current configuration.
 func (a *App) Cmd() AppCmd {
+	if a.Port == 0 {
+		a.Port = getFreePort()
+		revel.HTTPPort = a.Port
+	}
 	a.cmd = NewAppCmd(a.BinaryPath, a.Port)
 	return a.cmd
 }


### PR DESCRIPTION
In order to make it possible to run multiple concurrent Revel test suites on a single machine it is important to run them on random ports to avoid collisions. 
This pull request adds support for that.