### PR TITLE
Fix compilation error visibility

### DIFF
--- a/parser/reflect.go
+++ b/parser/reflect.go
@@ -46,6 +46,9 @@ func ProcessSource(paths *model.RevelContainer) (_ *model.SourceInfo, compileErr
 
 		// Start walking the directory tree.
 		compileError = utils.Walk(root, pc.processPath)
+		if compileError != nil {
+			return
+		}
 	}
 
 	return pc.srcInfo, compileError


### PR DESCRIPTION
If we do not return when an error occurs, the error will be overwritten with nil on the next iteration. The compilation error will never be written to the logging output. 

Any chance this could make it into master and become a 0.20.3 release? 