### PR TITLE
eliminates package bug on silent build problems 

### DIFF
--- a/revel/build.go
+++ b/revel/build.go
@@ -69,7 +69,9 @@ func buildApp(c *model.CommandConfig) (err error) {
 		return
 	}
 
-	buildSafetyCheck(destPath)
+	if err = buildSafetyCheck(destPath); err != nil {
+		return
+	}
 
 	// Ensure the application can be built, this generates the main file
 	app, err := harness.Build(c, revel_paths)

--- a/revel/package.go
+++ b/revel/package.go
@@ -86,7 +86,9 @@ func packageApp(c *model.CommandConfig) (err error) {
 	}
 	c.Build.TargetPath = tmpDir
 	c.Build.CopySource = c.Package.CopySource
-	buildApp(c)
+	if err = buildApp(c); err != nil {
+		return
+	}
 
 	// Create the zip file.
 


### PR DESCRIPTION
this fixes error when revel package creates tar without indicating that build had errors due to unhandled error