### PR TITLE
Go mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,8 @@ script:
   # Check build works with no-vendor flag
   - cd $GOPATH
   - export GO111MODULE=auto
-  - revel new  -a my/testapp2 --no-vendor
-  - revel test -a my/testapp2
+  - revel new  -a my/testapp2 --no-vendor -v
+  - revel test -a my/testapp2 -v
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   #- revel package my/testapp prod
 
   # Ensure the new-app flow works (plus the other commands).
-  - revel new     --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v
+  - revel new     --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 --package revelframework.com -v
   - revel test    --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v
   - revel clean   --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v
   - revel build   --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v -t build/testapp2

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,19 +47,23 @@ script:
   #- revel package my/testapp prod
 
   # Ensure the new-app flow works (plus the other commands).
-  - revel new     --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 --package revelframework.com -v
-  - revel test    --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v
-  - revel clean   --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v
-  - revel build   --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v -t build/testapp2
-  - revel build   --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v -t build/testapp2 -m prod
-  - revel package --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v
-  - revel package --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@develop" -a my/testapp2 -v -m prod
+  - revel new     --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 --package revelframework.com -v
+  - revel test    --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 -v
+  - revel clean   --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 -v
+  - revel build   --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 -v -t build/testapp2
+  - revel build   --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 -v -t build/testapp2 -m prod
+  - revel package --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 -v
+  - revel package --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 -v -m prod
 
   # Check build works with no-vendor flag
   - cd $GOPATH
   - export GO111MODULE=auto
   - revel new  -a my/testapp2 --no-vendor -v
   - revel test -a my/testapp2 -v
+
+  # Check non verbose build
+  - revel new     --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 --package revelframework.com
+  - revel test    --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,15 +55,17 @@ script:
   - revel package --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 -v
   - revel package --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 -v -m prod
 
+  - export INITIALWD=$PWD
   # Check build works with no-vendor flag
   - cd $GOPATH
   - export GO111MODULE=auto
   - revel new  -a my/testapp2 --no-vendor -v
   - revel test -a my/testapp2 -v
 
-  # Check non verbose build
-  - revel new     --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2 --package revelframework.com
-  - revel test    --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp2
+  # Check non verbose build, outside of GO path
+  - cd $INITIALWD
+  - revel new     --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp3 --package revelframework.com
+  - revel test    --gomod-flags "edit -replace=github.com/revel/revel=github.com/revel/revel@$REVEL_BRANCH" -a my/testapp3
 
 matrix:
   allow_failures:

--- a/harness/app.go
+++ b/harness/app.go
@@ -106,7 +106,7 @@ func (cmd AppCmd) Kill() {
 	if cmd.Cmd != nil && (cmd.ProcessState == nil || !cmd.ProcessState.Exited()) {
 		// Windows appears to send the kill to all threads, shutting down the
 		// server before this can, this check will ensure the process is still running
-		if _, err := os.FindProcess(int(cmd.Process.Pid));err!=nil {
+		if _, err := os.FindProcess(int(cmd.Process.Pid)); err != nil {
 			// Server has already exited
 			utils.Logger.Info("Server not running revel server pid", "pid", cmd.Process.Pid)
 			return
@@ -143,9 +143,9 @@ func (cmd AppCmd) Kill() {
 		}
 
 		if err != nil {
-			utils.Logger.Error(
-				"Revel app failed to kill process.",
-				"processid", cmd.Process.Pid,"error",err,
+			utils.Logger.Info(
+				"Revel app already exited.",
+				"processid", cmd.Process.Pid, "error", err,
 				"killerror", cmd.Process.Kill())
 			return
 		}

--- a/model/command_config.go
+++ b/model/command_config.go
@@ -236,6 +236,7 @@ func (c *CommandConfig) InitPackageResolver() {
 		utils.Logger.Info("Request for package ", "package", pkgName, "use vendor", c.Vendored)
 		var getCmd *exec.Cmd
 		if c.Vendored {
+			println("Downloading related packages")
 			getCmd = exec.Command(c.GoCmd, "mod", "tidy")
 		} else {
 			utils.Logger.Info("No vendor folder detected, not using dependency manager to import package", "package", pkgName)
@@ -245,6 +246,7 @@ func (c *CommandConfig) InitPackageResolver() {
 		utils.CmdInit(getCmd, !c.Vendored, c.AppPath)
 		utils.Logger.Info("Go get command ", "exec", getCmd.Path, "dir", getCmd.Dir, "args", getCmd.Args, "env", getCmd.Env, "package", pkgName)
 		output, err := getCmd.CombinedOutput()
+		println("Downloading related packages completed")
 		if err != nil {
 			utils.Logger.Error("Failed to import package", "error", err, "gopath", build.Default.GOPATH, "GO-ROOT", build.Default.GOROOT, "output", string(output))
 		}

--- a/model/command_config.go
+++ b/model/command_config.go
@@ -235,8 +235,8 @@ func (c *CommandConfig) InitPackageResolver() {
 	c.PackageResolver = func(pkgName string) error {
 		utils.Logger.Info("Request for package ", "package", pkgName, "use vendor", c.Vendored)
 		var getCmd *exec.Cmd
+		print("Downloading related packages ...")
 		if c.Vendored {
-			println("Downloading related packages")
 			getCmd = exec.Command(c.GoCmd, "mod", "tidy")
 		} else {
 			utils.Logger.Info("No vendor folder detected, not using dependency manager to import package", "package", pkgName)
@@ -246,10 +246,10 @@ func (c *CommandConfig) InitPackageResolver() {
 		utils.CmdInit(getCmd, !c.Vendored, c.AppPath)
 		utils.Logger.Info("Go get command ", "exec", getCmd.Path, "dir", getCmd.Dir, "args", getCmd.Args, "env", getCmd.Env, "package", pkgName)
 		output, err := getCmd.CombinedOutput()
-		println("Downloading related packages completed")
 		if err != nil {
 			utils.Logger.Error("Failed to import package", "error", err, "gopath", build.Default.GOPATH, "GO-ROOT", build.Default.GOROOT, "output", string(output))
 		}
+		println(" completed.")
 
 		return nil
 	}

--- a/model/command_config.go
+++ b/model/command_config.go
@@ -174,8 +174,10 @@ func (c *CommandConfig) initAppFolder() (err error) {
 
 	// Use app folder to read the go.mod if it exists and extract the package information
 	goModFile := filepath.Join(appFolder, "go.mod")
+	utils.Logger.Info("Checking gomod, extracting from file", "path", goModFile,"exists", utils.Exists(goModFile))
 	if utils.Exists(goModFile) {
 		c.Vendored = true
+		utils.Logger.Info("Found go mod, extracting from file", "path", goModFile)
 		file, err := ioutil.ReadFile(goModFile)
 		if err != nil {
 			return err
@@ -220,7 +222,7 @@ func (c *CommandConfig) initAppFolder() (err error) {
 		c.AppPath = appFolder
 	}
 
-	utils.Logger.Info("Set application path", "path", c.AppPath)
+	utils.Logger.Info("Set application path", "path", c.AppPath, "vendored",c.Vendored, "importpath",c.ImportPath)
 	return nil
 }
 

--- a/model/source_info.go
+++ b/model/source_info.go
@@ -57,7 +57,6 @@ func (s *SourceInfo) TypesThatEmbed(targetType, packageFilter string) (filtered 
 
 			// Look through the embedded types to see if the current type is among them.
 			for _, embeddedType := range spec.EmbeddedTypes {
-
 				// If so, add this type's simple name to the nodeQueue, and its spec to
 				// the filtered list.
 				if typeSimpleName == embeddedType.String() {
@@ -111,6 +110,7 @@ func (s *SourceInfo) TypesThatEmbed(targetType, packageFilter string) (filtered 
 // ControllerSpecs returns the all the controllers that embeds
 // `revel.Controller`
 func (s *SourceInfo) ControllerSpecs() []*TypeInfo {
+	utils.Logger.Infof("Scanning controller specifications for types ","typePath",RevelImportPath + ".Controller", "speclen",len(s.controllerSpecs))
 	if s.controllerSpecs == nil {
 		s.controllerSpecs = s.TypesThatEmbed(RevelImportPath + ".Controller", "controllers")
 	}

--- a/model/source_info.go
+++ b/model/source_info.go
@@ -110,7 +110,7 @@ func (s *SourceInfo) TypesThatEmbed(targetType, packageFilter string) (filtered 
 // ControllerSpecs returns the all the controllers that embeds
 // `revel.Controller`
 func (s *SourceInfo) ControllerSpecs() []*TypeInfo {
-	utils.Logger.Infof("Scanning controller specifications for types ","typePath",RevelImportPath + ".Controller", "speclen",len(s.controllerSpecs))
+	utils.Logger.Info("Scanning controller specifications for types ","typePath",RevelImportPath + ".Controller", "speclen",len(s.controllerSpecs))
 	if s.controllerSpecs == nil {
 		s.controllerSpecs = s.TypesThatEmbed(RevelImportPath + ".Controller", "controllers")
 	}

--- a/parser2/source_info_processor.go
+++ b/parser2/source_info_processor.go
@@ -34,6 +34,7 @@ func (s *SourceInfoProcessor) processPackage(p *packages.Package) (sourceInfo *m
 	)
 	localImportMap := map[string]string{}
 	log := s.sourceProcessor.log.New("package", p.PkgPath)
+	log.Info("Processing package")
 	for _, tree := range p.Syntax {
 		for _, decl := range tree.Decls {
 
@@ -41,8 +42,8 @@ func (s *SourceInfoProcessor) processPackage(p *packages.Package) (sourceInfo *m
 			if !s.addImport(decl, p, localImportMap, log) {
 				continue
 			}
-			// log.Info("*** checking", p.Fset.Position(decl.Pos()).Filename)
 			spec, found := s.getStructTypeDecl(decl, p.Fset)
+			//log.Info("Checking file","filename", p.Fset.Position(decl.Pos()).Filename,"found",found)
 			if found {
 				if isController || isTest {
 					controllerSpec := s.getControllerSpec(spec, p, localImportMap)

--- a/parser2/source_info_processor.go
+++ b/parser2/source_info_processor.go
@@ -282,6 +282,7 @@ func (s *SourceInfoProcessor) getControllerSpec(spec *ast.TypeSpec, p *packages.
 		ImportPath:  p.PkgPath,
 		PackageName: p.Name,
 	}
+	log := s.sourceProcessor.log.New("file", p.Fset.Position(spec.Pos()).Filename,"position", p.Fset.Position(spec.Pos()).Line)
 	for _, field := range structType.Fields.List {
 		// If field.Names is set, it's not an embedded type.
 		if field.Names != nil {
@@ -330,7 +331,7 @@ func (s *SourceInfoProcessor) getControllerSpec(spec *ast.TypeSpec, p *packages.
 		} else {
 			var ok bool
 			if importPath, ok = s.sourceProcessor.importMap[pkgName]; !ok {
-				s.sourceProcessor.log.Error("Error: Failed to find import path for ", "package", pkgName, "type", typeName, "map", s.sourceProcessor.importMap)
+				log.Error("Error: Failed to find import path for ", "package", pkgName, "type", typeName, "map", s.sourceProcessor.importMap, "usedin", )
 				continue
 			}
 		}

--- a/parser2/source_processor.go
+++ b/parser2/source_processor.go
@@ -46,9 +46,11 @@ func NewSourceProcessor(revelContainer *model.RevelContainer) *SourceProcessor {
 }
 
 func (s *SourceProcessor) parse() (compileError error) {
+	print("Parsing packages, (may require download if not cached)...")
 	if compileError = s.addPackages(); compileError != nil {
 		return
 	}
+	println(" Completed")
 	if compileError = s.addImportMap(); compileError != nil {
 		return
 	}

--- a/parser2/source_processor.go
+++ b/parser2/source_processor.go
@@ -4,10 +4,15 @@ import (
 	"github.com/revel/cmd/model"
 	"golang.org/x/tools/go/packages"
 	"github.com/revel/cmd/utils"
-	"errors"
-
+	"go/parser"
 	"strings"
 	"github.com/revel/cmd/logger"
+	"os"
+	"path/filepath"
+	"go/ast"
+	"go/token"
+	"go/scanner"
+
 )
 
 type (
@@ -31,10 +36,6 @@ func ProcessSource(revelContainer *model.RevelContainer) (sourceInfo *model.Sour
 		processor.log.Infof("From parsers : Structures:%d InitImports:%d ValidationKeys:%d %v", len(sourceInfo.StructSpecs), len(sourceInfo.InitImportPaths), len(sourceInfo.ValidationKeys), sourceInfo.PackageMap)
 	}
 
-	if false {
-		compileError = errors.New("Incompleted")
-		utils.Logger.Panic("Not implemented")
-	}
 	return
 }
 
@@ -54,6 +55,7 @@ func (s *SourceProcessor) parse() (compileError error) {
 	if compileError = s.addSourceInfo(); compileError != nil {
 		return
 	}
+
 	s.sourceInfo.PackageMap = map[string]string{}
 	getImportFromMap := func(packagePath string) string {
 		for path := range s.packageMap {
@@ -76,7 +78,7 @@ func (s *SourceProcessor) parse() (compileError error) {
 // Using the packages.Load function load all the packages and type specifications (forces compile).
 // this sets the SourceProcessor.packageList         []*packages.Package
 func (s *SourceProcessor) addPackages() (err error) {
-	allPackages := []string{s.revelContainer.ImportPath + "/...", model.RevelImportPath + "/..."}
+	allPackages := []string{model.RevelImportPath + "/..."}
 	for _, module := range s.revelContainer.ModulePathMap {
 		allPackages = append(allPackages, module.ImportPath + "/...") // +"/app/controllers/...")
 	}
@@ -105,8 +107,111 @@ func (s *SourceProcessor) addPackages() (err error) {
 		Dir:s.revelContainer.AppPath,
 	}
 	s.packageList, err = packages.Load(config, allPackages...)
-	s.log.Info("Loaded packages ", "len results", len(s.packageList), "error", err)
+	s.log.Info("Loaded modules ", "len results", len(s.packageList), "error", err)
+
+
+	// Now process the files in the aap source folder	s.revelContainer.ImportPath + "/...",
+	err = utils.Walk(s.revelContainer.AppPath, s.processPath)
+	s.log.Info("Loaded apps and modules ", "len results", len(s.packageList), "error", err)
 	return
+}
+
+// This callback is used to build the packages for the "app" package. This allows us to
+// parse the source files without doing a full compile on them
+// This callback only processes folders, so any files passed to this will return a nil
+func (s *SourceProcessor) processPath(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		s.log.Error("Error scanning app source:", "error", err)
+		return nil
+	}
+
+	// Ignore files and folders not marked tmp (since those are generated)
+	if !info.IsDir() || info.Name() == "tmp" {
+		return nil
+	}
+
+	// Real work for processing the folder
+	pkgImportPath := s.revelContainer.ImportPath
+	appPath := s.revelContainer.BasePath
+	if appPath != path {
+		pkgImportPath = s.revelContainer.ImportPath + "/" + filepath.ToSlash(path[len(appPath)+1:])
+	}
+	// Parse files within the path.
+	var pkgMap map[string]*ast.Package
+	fset := token.NewFileSet()
+	pkgMap, err = parser.ParseDir(
+		fset,
+		path,
+		func(f os.FileInfo) bool {
+			return !f.IsDir() && !strings.HasPrefix(f.Name(), ".") && strings.HasSuffix(f.Name(), ".go")
+		},
+		0)
+
+	if err != nil {
+		if errList, ok := err.(scanner.ErrorList); ok {
+			var pos = errList[0].Pos
+			newError := &utils.SourceError{
+				SourceType:  ".go source",
+				Title:       "Go Compilation Error",
+				Path:        pos.Filename,
+				Description: errList[0].Msg,
+				Line:        pos.Line,
+				Column:      pos.Column,
+				SourceLines: utils.MustReadLines(pos.Filename),
+			}
+
+			errorLink := s.revelContainer.Config.StringDefault("error.link", "")
+			if errorLink != "" {
+				newError.SetLink(errorLink)
+			}
+			return newError
+		}
+
+		// This is exception, err already checked above. Here just a print
+		ast.Print(nil, err)
+		s.log.Fatal("Failed to parse dir", "error", err)
+	}
+	// Skip "main" packages.
+	delete(pkgMap, "main")
+
+	// Ignore packages that end with _test
+	// These cannot be included in source code that is not generated specifically as a test
+	for i := range pkgMap {
+		if len(i) > 6 {
+			if string(i[len(i)-5:]) == "_test" {
+				delete(pkgMap, i)
+			}
+		}
+	}
+
+	// If there is no code in this directory, skip it.
+	if len(pkgMap) == 0 {
+		return nil
+	}
+
+	// There should be only one package in this directory.
+	if len(pkgMap) > 1 {
+		for i := range pkgMap {
+			println("Found package ", i)
+		}
+		utils.Logger.Fatal("Most unexpected! Multiple packages in a single directory:", "packages", pkgMap)
+	}
+
+	// At this point there is only one package in the pkgs map,
+	p := &packages.Package{}
+	p.PkgPath = pkgImportPath
+	p.Fset = fset
+	for _, pkg := range pkgMap {
+		p.Name = pkg.Name
+		s.log.Info("Found package","pkg.Name", pkg.Name,"p.Name", p.PkgPath)
+		for filename,astFile := range pkg.Files {
+			p.Syntax = append(p.Syntax,astFile)
+			p.GoFiles = append(p.GoFiles,filename)
+		}
+	}
+	s.packageList = append(s.packageList, p)
+
+	return nil
 }
 
 // This function is used to populate a map so that we can lookup controller embedded types in order to determine

--- a/parser2/source_processor.go
+++ b/parser2/source_processor.go
@@ -43,6 +43,7 @@ func NewSourceProcessor(revelContainer *model.RevelContainer) *SourceProcessor {
 	s.sourceInfoProcessor = NewSourceInfoProcessor(s)
 	return s
 }
+
 func (s *SourceProcessor) parse() (compileError error) {
 	if compileError = s.addPackages(); compileError != nil {
 		return
@@ -71,11 +72,15 @@ func (s *SourceProcessor) parse() (compileError error) {
 
 	return
 }
+
+// Using the packages.Load function load all the packages and type specifications (forces compile).
+// this sets the SourceProcessor.packageList         []*packages.Package
 func (s *SourceProcessor) addPackages() (err error) {
 	allPackages := []string{s.revelContainer.ImportPath + "/...", model.RevelImportPath + "/..."}
 	for _, module := range s.revelContainer.ModulePathMap {
 		allPackages = append(allPackages, module.ImportPath + "/...") // +"/app/controllers/...")
 	}
+	s.log.Info("Reading packages", "packageList", allPackages)
 	//allPackages = []string{s.revelContainer.ImportPath + "/..."} //+"/app/controllers/..."}
 
 	config := &packages.Config{

--- a/parser2/source_processor.go
+++ b/parser2/source_processor.go
@@ -119,9 +119,7 @@ func (s *SourceProcessor) addImportMap() (err error) {
 		if len(p.Errors) > 0 {
 			// Generate a compile error
 			for _, e := range p.Errors {
-				if !strings.Contains(e.Msg, "fsnotify") {
-					err = utils.NewCompileError("", "", e)
-				}
+				s.log.Info("While reading packages encountered import error ignoring ", "PkgPath", p.PkgPath, "error", e)
 			}
 		}
 		for _, tree := range p.Syntax {

--- a/revel/new.go
+++ b/revel/new.go
@@ -72,7 +72,7 @@ func newApp(c *model.CommandConfig) (err error) {
 	// Check for an existing folder so we don't clobber it
 	_, err = build.Import(c.ImportPath, "", build.FindOnly)
 	if err == nil || !utils.Empty(c.AppPath) {
-		return utils.NewBuildError("Abort: Import path already exists.", "path", c.ImportPath)
+		return utils.NewBuildError("Abort: Import path already exists.", "path", c.ImportPath, "apppath", c.AppPath)
 	}
 
 	// checking and setting skeleton
@@ -112,6 +112,10 @@ func newApp(c *model.CommandConfig) (err error) {
 	fmt.Fprintln(os.Stdout, "Your application has been created in:\n  ", c.AppPath)
 	// Check to see if it should be run right off
 	if c.New.Run {
+		// Need to prep the run command
+		c.Run.ImportPath = c.ImportPath
+		updateRunConfig(c,nil)
+		c.UpdateImportPath()
 		runApp(c)
 	} else {
 		fmt.Fprintln(os.Stdout, "\nYou can run it with:\n   revel run -a ", c.ImportPath)

--- a/revel/new.go
+++ b/revel/new.go
@@ -203,13 +203,13 @@ func setApplicationPath(c *model.CommandConfig) (err error) {
 	// revel/revel#1014 validate relative path, we cannot use built-in functions
 	// since Go import path is valid relative path too.
 	// so check basic part of the path, which is "."
-	if filepath.IsAbs(c.ImportPath) || strings.HasPrefix(c.ImportPath, ".") {
-		utils.Logger.Fatalf("Abort: '%s' looks like a directory.  Please provide a Go import path instead.",
-			c.ImportPath)
-	}
 
 	// If we are running a vendored version of Revel we do not need to check for it.
 	if !c.Vendored {
+		if filepath.IsAbs(c.ImportPath) || strings.HasPrefix(c.ImportPath, ".") {
+			utils.Logger.Fatalf("Abort: '%s' looks like a directory.  Please provide a Go import path instead.",
+				c.ImportPath)
+		}
 		_, err = build.Import(model.RevelImportPath, "", build.FindOnly)
 		if err != nil {
 			//// Go get the revel project

--- a/revel/run.go
+++ b/revel/run.go
@@ -11,9 +11,7 @@ import (
 	"github.com/revel/cmd/harness"
 	"github.com/revel/cmd/model"
 	"github.com/revel/cmd/utils"
-	"go/build"
 	"os"
-	"path/filepath"
 )
 
 var cmdRun = &Command{
@@ -116,10 +114,7 @@ func updateRunConfig(c *model.CommandConfig, args []string) bool {
 
 // Returns true if this is an absolute path or a relative gopath
 func runIsImportPath(pathToCheck string) bool {
-	if _, err := build.Import(pathToCheck, "", build.FindOnly); err == nil {
-		return true
-	}
-	return filepath.IsAbs(pathToCheck)
+	return utils.DirExists(pathToCheck)
 }
 
 // Called to run the app

--- a/revel/version_test.go
+++ b/revel/version_test.go
@@ -34,8 +34,8 @@ func TestVersion(t *testing.T) {
 		a.Nil(main.Commands[model.VERSION].RunWith(c), "Failed to run version-test")
 	})
 	if !t.Failed() {
-		if err := os.RemoveAll(gopath); err != nil {
-			a.Fail("Failed to remove test path")
+		if err := os.RemoveAll(gopath); err != nil && err!=os.ErrNotExist {
+			a.Fail("Failed to remove test path",err.Error())
 		}
 	}
 }

--- a/utils/file.go
+++ b/utils/file.go
@@ -322,8 +322,8 @@ func Empty(dirname string) bool {
 // Find the full source dir for the import path, uses the build.Default.GOPATH to search for the directory
 func FindSrcPaths(appPath string, packageList []string, packageResolver func(pkgName string) error) (sourcePathsmap map[string]string, err error) {
 	sourcePathsmap, missingList, err := findSrcPaths(appPath, packageList)
-	if err != nil && packageResolver != nil || len(missingList)>0 {
-		Logger.Info("Failed to find package, attempting to call resolver for missing packages","missing packages",missingList)
+	if err != nil && packageResolver != nil || len(missingList) > 0 {
+		Logger.Info("Failed to find package, attempting to call resolver for missing packages", "missing packages", missingList)
 		for _, item := range missingList {
 			if err = packageResolver(item); err != nil {
 				return
@@ -352,25 +352,25 @@ func findSrcPaths(appPath string, packagesList []string) (sourcePathsmap map[str
 		Dir:appPath,
 	}
 	sourcePathsmap = map[string]string{}
-	Logger.Infof("Environment path %s root %s config env %s", os.Getenv("GOPATH"), os.Getenv("GOROOT"),config.Env)
+	Logger.Infof("Environment path %s root %s config env %s", os.Getenv("GOPATH"), os.Getenv("GOROOT"), config.Env)
 
 	pkgs, err := packages.Load(config, packagesList...)
-	Logger.Infof("Environment path %s root %s config env %s", os.Getenv("GOPATH"), os.Getenv("GOROOT"),config.Env)
+	Logger.Infof("Environment path %s root %s config env %s", os.Getenv("GOPATH"), os.Getenv("GOROOT"), config.Env)
 	Logger.Info("Loaded packages ", "len results", len(pkgs), "error", err, "basedir", appPath)
 	for _, packageName := range packagesList {
-		 found := false
+		found := false
 		log := Logger.New("seeking", packageName)
 		for _, pck := range pkgs {
 			log.Info("Found package", "package", pck.ID)
 			if pck.ID == packageName {
 				if pck.Errors != nil && len(pck.Errors) > 0 {
-					log.Info("Error ", "count", len(pck.Errors), "App Import Path", pck.ID, "errors", pck.Errors)
-					continue
+					log.Error("Error ", "count", len(pck.Errors), "App Import Path", pck.ID, "filesystem path", pck.PkgPath, "errors", pck.Errors)
+					// continue
 
 				}
 				//a,_ := pck.MarshalJSON()
 				log.Info("Found ", "count", len(pck.GoFiles), "App Import Path", pck.ID, "apppath", appPath)
-				if len(pck.GoFiles)>0 {
+				if len(pck.GoFiles) > 0 {
 					sourcePathsmap[packageName] = filepath.Dir(pck.GoFiles[0])
 					found = true
 				}

--- a/utils/file.go
+++ b/utils/file.go
@@ -203,7 +203,8 @@ func Walk(root string, walkFn filepath.WalkFunc) error {
 	return fsWalk(root, root, walkFn)
 }
 
-// Walk the tree using the function
+// Walk the path tree using the function
+// Every file found will call the function
 func fsWalk(fname string, linkName string, walkFn filepath.WalkFunc) error {
 	fsWalkFunc := func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/utils/file.go
+++ b/utils/file.go
@@ -309,9 +309,13 @@ func Exists(filename string) bool {
 // empty returns true if the given directory is empty.
 // the directory must exist.
 func Empty(dirname string) bool {
+	if !DirExists(dirname) {
+		return true
+	}
 	dir, err := os.Open(dirname)
 	if err != nil {
 		Logger.Infof("error opening directory: %s", err)
+		return false
 	}
 	defer func() {
 		_ = dir.Close()


### PR DESCRIPTION
Removed scanning all the import statements, this is not needed
Added recursive scan for revel import path to pick up testunits
Added a check to see if harness had already started, saves a recompile on load
Added check to source info for local import renames
Removed the go/build check for path and just check existence of the path
Formatting updates