### PR TITLE
harness: interrupt process on windows as well

### DIFF
--- a/harness/app.go
+++ b/harness/app.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"runtime"
 	"sync"
 	"time"
 
@@ -133,11 +132,8 @@ func (cmd AppCmd) Kill() {
 
 		// Send an interrupt signal to allow for a graceful shutdown
 		utils.Logger.Info("Killing revel server pid", "pid", cmd.Process.Pid)
-		var err error
-		if runtime.GOOS != "windows" {
-			// os.Interrupt is not available on windows
-			err = cmd.Process.Signal(os.Interrupt)
-		}
+
+		err := cmd.Process.Signal(os.Interrupt)
 
 		if err != nil {
 			utils.Logger.Info(


### PR DESCRIPTION
I tested that this works on windows 10 build 19042.746 with 

```
go version go1.15.6 windows/amd64
```

Waiting for 60 seconds is unresponsive, and always killing and relaunching the proxy is annoying.

fixes revel/revel#1521