### PR TITLE
Get rid of redundant space in the output of `revel new -a`

### DIFF
--- a/revel/new.go
+++ b/revel/new.go
@@ -118,7 +118,7 @@ func newApp(c *model.CommandConfig) (err error) {
 		c.UpdateImportPath()
 		runApp(c)
 	} else {
-		fmt.Fprintln(os.Stdout, "\nYou can run it with:\n   revel run -a ", c.ImportPath)
+		fmt.Fprintln(os.Stdout, "\nYou can run it with:\n   revel run -a", c.ImportPath)
 	}
 	return
 }


### PR DESCRIPTION
This is a total nitpick PR, but hopefully such things are welcome from time to time. 😅

Currently, the output of `revel new -a myapp` includes a double space before the app name:

```
You can run it with:
   revel run -a  myapp
```

This removes the space so the output looks like this:
```
You can run it with:
   revel run -a myapp
```