### PR TITLE
Remove redundant dependency which doesn't let go get this

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/inconshreveable/log15 v0.0.0-20200109203555-b30bc20e4fd1 // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-colorable v0.1.6
-	github.com/myesui/uuid v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/revel/config v0.21.0
 	github.com/revel/log15 v2.11.20+incompatible


### PR DESCRIPTION
`go get` right now fails:

```text
$ go get github.com/revel/cmd
go get: github.com/revel/cmd@v0.21.1 updating to
	github.com/revel/cmd@v1.0.3 requires
	github.com/myesui/uuid@v1.0.0: reading github.com/myesui/uuid/go.mod at revision v1.0.0: unknown revision v1.0.0
```

Because that repository doesn't exist.

The correct one is already in `go.mod`:

https://github.com/revel/cmd/blob/3cec19ee6293b8713e2fe32a8a469a7818ce9816/go.mod#L20

closes #203

_(I think)_