### PR TITLE
Updated Launch code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea/
 *.iml
-
+.temp/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,7 +41,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceRoot}/.temp/revel/reveltest/app/tmp/main.go",
-            "args": ["-port=34373","-importPath=revel.com/testproject/reveltest", "-runMode={\"mode\":\"dev\", \"specialUseFlag\":true,\"packagePathMap\":{\"github.com/revel/modules/static\":\"/home/notzippy/go/pkg/mod/github.com/revel/modules@v1.0.0/static\",\"github.com/revel/modules/testrunner\":\"/home/notzippy/go/pkg/mod/github.com/revel/modules@v1.0.0/testrunner\",\"github.com/revel/revel\":\"/home/notzippy/go/pkg/mod/github.com/revel/revel@v1.0.0\",\"revel.com/testproject/reveltest\":\"/mnt/DevSystem/Work/Workareas/revel/revel3/cmd/.temp/revel/reveltest\"}}"],
+            "args": ["-port=9000","-importPath=revel.com/testproject/reveltest", "-runMode={\"mode\":\"dev\", \"specialUseFlag\":true,\"packagePathMap\":{\"github.com/revel/modules/static\":\"/home/notzippy/go/pkg/mod/github.com/revel/modules@v1.0.0/static\",\"github.com/revel/modules/testrunner\":\"/home/notzippy/go/pkg/mod/github.com/revel/modules@v1.0.0/testrunner\",\"github.com/revel/revel\":\"/home/notzippy/go/pkg/mod/github.com/revel/revel@v1.0.0\",\"revel.com/testproject/reveltest\":\"/mnt/DevSystem/Work/Workareas/revel/revel3/cmd/.temp/revel/reveltest\"}}"],
             "env": {
                 "GOPATH": "${workspaceRoot}/.temp/revel/GOPATH"
               },            

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,12 +16,12 @@
             "name": "Create new",
             "type": "go",
             "request": "launch",
-            "preLaunchTask": "Clean",
+            "preLaunchTask": "Clean-Test-Project",
             "mode": "auto",
             "program": "${workspaceRoot}/revel",
-            "args": ["new", "-a", "/tmp/revel/aaa"],
+            "args": ["new", "-v","-a", "${workspaceRoot}/.temp/revel/reveltest", "-p","revel.com/testproject"],
             "env": {
-                "GOPATH": "/tmp/revel/GOPATH"
+                "GOPATH": "${workspaceRoot}/.temp/revel/GOPATH"
               },            
         },
         {
@@ -30,9 +30,20 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceRoot}/revel",
-            "args": ["run","-v", "-a", "/tmp/revel/aaa"],
+            "args": ["run","-v", "-v","-a", "${workspaceRoot}/.temp/revel/reveltest"],
             "env": {
-                "GOPATH": "/tmp/revel/GOPATH"
+                "GOPATH": "${workspaceRoot}/.temp/revel/GOPATH"
+              },            
+        },
+        {
+            "name": "Run program Directly",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}/.temp/revel/reveltest/app/tmp/main.go",
+            "args": ["-port=34373","-importPath=revel.com/testproject/reveltest", "-runMode={\"mode\":\"dev\", \"specialUseFlag\":true,\"packagePathMap\":{\"github.com/revel/modules/static\":\"/home/notzippy/go/pkg/mod/github.com/revel/modules@v1.0.0/static\",\"github.com/revel/modules/testrunner\":\"/home/notzippy/go/pkg/mod/github.com/revel/modules@v1.0.0/testrunner\",\"github.com/revel/revel\":\"/home/notzippy/go/pkg/mod/github.com/revel/revel@v1.0.0\",\"revel.com/testproject/reveltest\":\"/mnt/DevSystem/Work/Workareas/revel/revel3/cmd/.temp/revel/reveltest\"}}"],
+            "env": {
+                "GOPATH": "${workspaceRoot}/.temp/revel/GOPATH"
               },            
         }
     ]

--- a/.vscode/load.sh
+++ b/.vscode/load.sh
@@ -1,0 +1,1 @@
+http_load -rate 5 -seconds 10 load.web

--- a/.vscode/load.web
+++ b/.vscode/load.web
@@ -1,0 +1,2 @@
+http://localhost:9000/
+http://localhost:9000/miss

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,14 @@
             "label": "Clean-Test-Project",
             "type": "shell",
             "command": "rm -rf ${workspaceRoot}/.temp/revel/testproject"
-        }
+        },
+        {
+            "label": "Update Go Mod",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceRoot}/.temp/revel/testproject"
+            },
+            "command": "go mod tidy && go mod edit -replace github.com/revel/revel => ../../../revel"
+        },
     ]
 } 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,9 +4,9 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Clean",
+            "label": "Clean-Test-Project",
             "type": "shell",
-            "command": "rm -rf /tmp/revel/aaa"
+            "command": "rm -rf ${workspaceRoot}/.temp/revel/testproject"
         }
     ]
 } 

--- a/harness/build.go
+++ b/harness/build.go
@@ -26,6 +26,7 @@ import (
 
 var importErrorPattern = regexp.MustCompile("cannot find package \"([^\"]+)\"")
 var importErrorPattern2 = regexp.MustCompile("no required module provides package ([^;]+)+")
+var addPackagePattern = regexp.MustCompile(`to add:\n\tgo get (.*)\n`)
 
 type ByString []*model.TypeInfo
 
@@ -213,6 +214,10 @@ func Build(c *model.CommandConfig, paths *model.RevelContainer) (_ *App, err err
 		matches := importErrorPattern.FindAllStringSubmatch(stOutput, -1)
 		if matches == nil {
 			matches = importErrorPattern2.FindAllStringSubmatch(stOutput, -1)
+		}
+		if matches == nil {
+			matches = addPackagePattern.FindAllStringSubmatch(stOutput, -1)
+
 		}
 		utils.Logger.Info("Build failed checking for missing imports", "message", stOutput, "missing_imports", len(matches))
 		if matches == nil {

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -42,6 +42,8 @@ var (
 	doNotWatch = []string{"tmp", "views", "routes"}
 
 	lastRequestHadError int32
+	startupError        int32
+	startupErrorText    error
 )
 
 // Harness reverse proxies requests to the application server.
@@ -255,7 +257,7 @@ func (h *Harness) refresh() (err *utils.SourceError) {
 			if len(h.app.PackagePathMap) > 0 {
 				paths, _ = json.Marshal(h.app.PackagePathMap)
 			}
-			runMode = fmt.Sprintf(`{"mode":"%s", "specialUseFlag":%v,"packagePathMap":%s}`, h.app.Paths.RunMode, h.config.Verbose, string(paths))
+			runMode = fmt.Sprintf(`{"mode":"%s", "specialUseFlag":%v,"packagePathMap":%s}`, h.app.Paths.RunMode, h.config.Verbose[0], string(paths))
 		}
 		if err2 := h.app.Cmd(runMode).Start(h.config); err2 != nil {
 			utils.Logger.Error("Could not start application", "error", err2)
@@ -297,6 +299,7 @@ func (h *Harness) Run() {
 	paths = append(paths, h.paths.CodePaths...)
 	h.watcher = watcher.NewWatcher(h.paths, false)
 	h.watcher.Listen(h, paths...)
+
 	go h.Refresh()
 	// h.watcher.Notify()
 

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -243,7 +243,7 @@ func (h *Harness) refresh() (err *utils.SourceError) {
 		}
 		err = &utils.SourceError{
 			Title:       "App failed to start up",
-			Description: err.Error(),
+			Description: newErr.Error(),
 		}
 		return
 	}

--- a/model/command_config.go
+++ b/model/command_config.go
@@ -165,8 +165,6 @@ func (c *CommandConfig) initAppFolder() (err error) {
 		} else {
 			appFolder = filepath.Join(wd, appFolder)
 		}
-	} else if strings.Contains(appFolder, ".") {
-		appFolder = filepath.Join(wd, filepath.Base(c.ImportPath))
 	} else if !filepath.IsAbs(appFolder) {
 		appFolder = filepath.Join(wd, appFolder)
 	}

--- a/revel/new.go
+++ b/revel/new.go
@@ -19,7 +19,7 @@ import (
 )
 
 var cmdNew = &Command{
-	UsageLine: "new -i [path] -s [skeleton]",
+	UsageLine: "new -i [path] -s [skeleton] -p [package name]",
 	Short:     "create a skeleton Revel application",
 	Long: `
 New creates a few files to get a new Revel application running quickly.

--- a/revel/run.go
+++ b/revel/run.go
@@ -133,7 +133,7 @@ func runApp(c *model.CommandConfig) (err error) {
 	// If the app is run in "watched" mode, use the harness to run it.
 	if revelPath.Config.BoolDefault("watch", true) && revelPath.Config.BoolDefault("watch.code", true) {
 		utils.Logger.Info("Running in watched mode.")
-		runMode := fmt.Sprintf(`{"mode":"%s", "specialUseFlag":%v}`, revelPath.RunMode, c.Verbose)
+		runMode := fmt.Sprintf(`{"mode":"%s", "specialUseFlag":%v}`, revelPath.RunMode, c.Verbose[0])
 		if c.HistoricMode {
 			runMode = revelPath.RunMode
 		}
@@ -152,7 +152,7 @@ func runApp(c *model.CommandConfig) (err error) {
 	if len(app.PackagePathMap) > 0 {
 		paths, _ = json.Marshal(app.PackagePathMap)
 	}
-	runMode := fmt.Sprintf(`{"mode":"%s", "specialUseFlag":%v,"packagePathMap":%s}`, app.Paths.RunMode, c.Verbose, string(paths))
+	runMode := fmt.Sprintf(`{"mode":"%s", "specialUseFlag":%v,"packagePathMap":%s}`, app.Paths.RunMode, c.Verbose[0], string(paths))
 	if c.HistoricMode {
 		runMode = revelPath.RunMode
 	}

--- a/revel/test.go
+++ b/revel/test.go
@@ -112,7 +112,7 @@ func testApp(c *model.CommandConfig) (err error) {
 	if len(app.PackagePathMap) > 0 {
 		paths, _ = json.Marshal(app.PackagePathMap)
 	}
-	runMode := fmt.Sprintf(`{"mode":"%s", "specialUseFlag":%v,"packagePathMap":%s}`, app.Paths.RunMode, c.Verbose, string(paths))
+	runMode := fmt.Sprintf(`{"mode":"%s", "specialUseFlag":%v,"packagePathMap":%s}`, app.Paths.RunMode, c.Verbose[0], string(paths))
 	if c.HistoricMode {
 		runMode = app.Paths.RunMode
 	}

--- a/utils/command.go
+++ b/utils/command.go
@@ -17,6 +17,9 @@ func CmdInit(c *exec.Cmd, addGoPath bool, basePath string) {
 	c.Env = ReducedEnv(addGoPath)
 
 }
+
+// ReducedEnv returns a list of environment vairables by using os.Env
+// it will remove the GOPATH, GOROOT if addGoPath is true
 func ReducedEnv(addGoPath bool) []string {
 	realPath := &bytes.Buffer{}
 	env := []string{}
@@ -38,7 +41,7 @@ func ReducedEnv(addGoPath bool) []string {
 		if pair[0] == "GOMODCACHE" {
 			continue
 		} else if !addGoPath && (pair[0] == "GOPATH" || pair[0] == "GOROOT") {
-
+			continue
 		}
 		env = append(env, e)
 	}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -52,7 +52,7 @@ type Watcher struct {
 // Creates a new watched based on the container.
 func NewWatcher(paths *model.RevelContainer, eagerRefresh bool) *Watcher {
 	return &Watcher{
-		forceRefresh:   false,
+		forceRefresh:   true,
 		lastError:      -1,
 		paths:          paths,
 		refreshTimerMS: time.Duration(paths.Config.IntDefault("watch.rebuild.delay", 1000)),


### PR DESCRIPTION
Added output to error stack, so terminal errors are displayed
Ficed c.Verbose, it was changed to an array which causes issues launching
Removed . notation from doing anything special. This was already replaced with the -p CLI option
Added documentaiton on adding the package name
Started watcher with force refresh.