### PR TITLE
Issue-219 Key line number mismatch. 

### DIFF
--- a/parser2/source_info_processor.go
+++ b/parser2/source_info_processor.go
@@ -157,10 +157,10 @@ func (s *SourceInfoProcessor) getValidation(funcDecl *ast.FuncDecl, p *packages.
 		}
 
 		if typeExpr := model.NewTypeExprFromAst("", key); typeExpr.Valid {
-			lineKeys[p.Fset.Position(callExpr.End()).Line] = typeExpr.TypeName("")
+			lineKeys[p.Fset.Position(callExpr.Pos()).Line] = typeExpr.TypeName("")
 		} else {
 			s.sourceProcessor.log.Error("Error: Failed to generate key for field validation. Make sure the field name is valid.", "file", p.PkgPath,
-				"line", p.Fset.Position(callExpr.End()).Line, "function", funcDecl.Name.String())
+				"line", p.Fset.Position(callExpr.Pos()).Line, "function", funcDecl.Name.String())
 		}
 		return true
 	})


### PR DESCRIPTION
Changed the default validation keys to be keyed by the first line line number of the "code" instead of the last.
This is because the validation.go in revel expects it to be the first and the fields level validation messages were not showing.

Fixes https://github.com/revel/cmd/issues/219
